### PR TITLE
Added changes to support data annotations for the ado-net repository

### DIFF
--- a/src/DotNetToolkit.Repository.AdoNet/Internal/DbSqlExpressionTranslator.cs
+++ b/src/DotNetToolkit.Repository.AdoNet/Internal/DbSqlExpressionTranslator.cs
@@ -98,12 +98,12 @@
                     variableExpression = secondExpression;
                 }
 
-                var property = ExpressionHelper.GetPropertyName(variableExpression);
+                var propertyInfo = ExpressionHelper.GetPropertyInfo(variableExpression);
                 var value = ExpressionHelper.GetPropertyValue(constantExpression);
                 var tableType = ExpressionHelper.GetMemberExpression(variableExpression).Expression.Type;
                 var tableName = _config.GetTableName(tableType);
                 var tableAlias = _config.GetTableAlias(tableName);
-                var columnAlias = _config.GetColumnAlias(tableName, property);
+                var columnAlias = _config.GetColumnAlias(propertyInfo);
 
                 _sb.Append($"[{tableAlias}].[{columnAlias}]");
 
@@ -129,12 +129,12 @@
         {
             var variableExpression = node.Left;
             var constantExpression = node.Right as ConstantExpression;
-            var property = ExpressionHelper.GetPropertyName(variableExpression);
+            var propertyInfo = ExpressionHelper.GetPropertyInfo(variableExpression);
             var value = ExpressionHelper.GetPropertyValue(constantExpression);
             var tableType = ExpressionHelper.GetMemberExpression(variableExpression).Expression.Type;
             var tableName = _config.GetTableName(tableType);
             var tableAlias = _config.GetTableAlias(tableName);
-            var columnAlias = _config.GetColumnAlias(tableName, property);
+            var columnAlias = _config.GetColumnAlias(propertyInfo);
 
             _sb.Append($"[{tableAlias}].[{columnAlias}]");
 

--- a/src/DotNetToolkit.Repository.AdoNet/Internal/DbSqlSelectStatementConfig.cs
+++ b/src/DotNetToolkit.Repository.AdoNet/Internal/DbSqlSelectStatementConfig.cs
@@ -1,5 +1,7 @@
 ﻿namespace DotNetToolkit.Repository.AdoNet.Internal
 {
+    using Helpers;
+    using Properties;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -42,9 +44,10 @@
 
         #region Public Methods
 
-        public string GenerateTableAlias(Type tableType, string tableName)
+        public string GenerateTableAlias(Type tableType)
         {
             var tableAlias = $"Extent{_tableAliasCount++}";
+            var tableName = tableType.GetTableName();
 
             _tableAliasMapping.Add(tableName, tableAlias);
             _tableNameAndTypeMapping.Add(tableName, tableType);
@@ -54,9 +57,11 @@
             return tableAlias;
         }
 
-        public string GenerateColumnAlias(string tableName, string columnName)
+        public string GenerateColumnAlias(PropertyInfo pi)
         {
+            var columnName = pi.GetColumnName();
             var columnAlias = columnName;
+            var tableName = pi.DeclaringType.GetTableName();
 
             if (_columnAliasMappingCount.TryGetValue(columnName, out int columnAliasCount))
             {
@@ -94,9 +99,16 @@
             return _tableTypeAndNameMapping[tableType];
         }
 
-        public string GetColumnAlias(string tableName, string columnName)
+        public string GetColumnAlias(PropertyInfo pi)
         {
-            return _tableColumnAliasMapping[tableName][columnName];
+            var columnName = pi.GetColumnName();
+            var tableName = pi.DeclaringType.GetTableName();
+            var columnMapping = _tableColumnAliasMapping[tableName];
+
+            if (!columnMapping.ContainsKey(columnName))
+                throw new InvalidOperationException(string.Format(Resources.InvalidColumnName, columnName));
+
+            return columnMapping[columnName];
         }
 
         public string GetColumnName(string columnAlias)

--- a/src/DotNetToolkit.Repository.AdoNet/Properties/Resources.Designer.cs
+++ b/src/DotNetToolkit.Repository.AdoNet/Properties/Resources.Designer.cs
@@ -9,7 +9,6 @@
 //------------------------------------------------------------------------------
 
 namespace DotNetToolkit.Repository.AdoNet.Properties {
-    using System;
     using System.Reflection;
 
 
@@ -67,6 +66,15 @@ namespace DotNetToolkit.Repository.AdoNet.Properties {
         internal static string ArgumentCannotBeNullOrEmptyString {
             get {
                 return ResourceManager.GetString("ArgumentCannotBeNullOrEmptyString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The column name {0} is not valid..
+        /// </summary>
+        internal static string InvalidColumnName {
+            get {
+                return ResourceManager.GetString("InvalidColumnName", resourceCulture);
             }
         }
         

--- a/src/DotNetToolkit.Repository.AdoNet/Properties/Resources.resx
+++ b/src/DotNetToolkit.Repository.AdoNet/Properties/Resources.resx
@@ -126,4 +126,7 @@
   <data name="ArgumentCannotBeNullOrEmptyString" xml:space="preserve">
     <value>Cannot be null or an empty string.</value>
   </data>
+  <data name="InvalidColumnName" xml:space="preserve">
+    <value>The column name {0} is not valid.</value>
+  </data>
 </root>

--- a/src/DotNetToolkit.Repository.InMemory/InMemoryRepositoryBase.cs
+++ b/src/DotNetToolkit.Repository.InMemory/InMemoryRepositoryBase.cs
@@ -1,6 +1,7 @@
 ﻿namespace DotNetToolkit.Repository.InMemory
 {
     using FetchStrategies;
+    using Helpers;
     using Logging;
     using Properties;
     using System;
@@ -128,7 +129,7 @@
         /// <returns>The new generated primary id.</returns>
         protected virtual TKey GenerateTemporaryPrimaryKey()
         {
-            var propertyInfo = GetPrimaryKeyPropertyInfo();
+            var propertyInfo = ConventionHelper.GetPrimaryKeyPropertyInfo<TEntity>();
             var propertyType = propertyInfo.PropertyType;
             if (propertyType == typeof(int))
             {
@@ -168,7 +169,7 @@
 
             if (key != null && key.Equals(default(TKey)))
             {
-                key = GetPrimaryKey(entity);
+                key = entity.GetPrimaryKeyPropertyValue<TKey>();
 
                 if (key != null && key.Equals(default(TKey)))
                 {
@@ -188,7 +189,7 @@
         /// </summary>
         protected override void DeleteItem(TEntity entity)
         {
-            var key = GetPrimaryKey(entity);
+            var key = entity.GetPrimaryKeyPropertyValue<TKey>();
             var hasTemporaryKey = false;
 
             if (key != null && key.Equals(default(TKey)))
@@ -208,7 +209,7 @@
         /// </summary>
         protected override void UpdateItem(TEntity entity)
         {
-            var key = GetPrimaryKey(entity);
+            var key = entity.GetPrimaryKeyPropertyValue<TKey>();
             var hasTemporaryKey = false;
 
             if (key != null && key.Equals(default(TKey)))
@@ -241,7 +242,7 @@
                         if (entitySet.HasTemporaryKey)
                         {
                             key = GeneratePrimaryKey();
-                            SetPrimaryKey(entitySet.Entity, key);
+                            entitySet.Entity.SetPrimaryKeyPropertyValue(key);
                         }
                         else if (context.ContainsKey(key))
                         {

--- a/src/DotNetToolkit.Repository/DotNetToolkit.Repository.csproj
+++ b/src/DotNetToolkit.Repository/DotNetToolkit.Repository.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.1" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/DotNetToolkit.Repository/Helpers/ConventionHelper.cs
+++ b/src/DotNetToolkit.Repository/Helpers/ConventionHelper.cs
@@ -3,10 +3,16 @@
     using Properties;
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.ComponentModel.DataAnnotations.Schema;
     using System.Globalization;
+    using System.Linq;
     using System.Reflection;
 
-    internal static class ConventionHelper
+    /// <summary>
+    /// Represents a convention helper for the repositories.
+    /// </summary>
+    public static class ConventionHelper
     {
         /// <summary>
         /// Gets the value of the specified object primary key property.
@@ -15,13 +21,15 @@
         /// <returns>The property value.</returns>
         /// <exception cref="System.ArgumentNullException"><paramref name="obj" /> is <c>null</c>.</exception>
         /// <exception cref="System.InvalidOperationException">Primary key could not be found for the entity type.</exception>
-        public static object GetPrimaryKeyPropertyValue(object obj)
+        public static T GetPrimaryKeyPropertyValue<T>(this object obj)
         {
             if (obj == null)
                 throw new ArgumentNullException(nameof(obj));
 
-            var propertyInfo = GetPrimaryKeyPropertyInfo(obj.GetType());
-            return propertyInfo.GetValue(obj, null);
+            var propertyInfo = obj.GetType().GetPrimaryKeyPropertyInfo();
+            var value = propertyInfo.GetValue(obj, null);
+
+            return (T)Convert.ChangeType(value, typeof(T));
         }
 
         /// <summary>
@@ -31,12 +39,12 @@
         /// <param name="value">The value to set for the property.</param>
         /// <exception cref="System.ArgumentNullException"><paramref name="obj" /> is <c>null</c>.</exception>
         /// <exception cref="System.InvalidOperationException">The instance of entity type requires a primary key to be defined.</exception>
-        public static void SetPrimaryKeyPropertyValue(object obj, object value)
+        public static void SetPrimaryKeyPropertyValue(this object obj, object value)
         {
             if (obj == null)
                 throw new ArgumentNullException(nameof(obj));
 
-            var propertyInfo = GetPrimaryKeyPropertyInfo(obj.GetType());
+            var propertyInfo = obj.GetType().GetPrimaryKeyPropertyInfo();
             propertyInfo.SetValue(obj, value, null);
         }
 
@@ -47,22 +55,175 @@
         /// <returns>The primary key property info.</returns>
         /// <exception cref="System.ArgumentNullException"><paramref name="entityType" /> is <c>null</c>.</exception>
         /// <exception cref="System.InvalidOperationException">The instance of entity type requires a primary key to be defined.</exception>
-        public static PropertyInfo GetPrimaryKeyPropertyInfo(Type entityType)
+        public static PropertyInfo GetPrimaryKeyPropertyInfo(this Type entityType)
         {
             if (entityType == null)
                 throw new ArgumentNullException(nameof(entityType));
 
-            foreach (var propertyName in GetPrimaryKeyNameChecks(entityType))
-            {
-                var propInfo = entityType.GetTypeInfo().GetDeclaredProperty(propertyName);
+            var propertyInfo = entityType
+                .GetRuntimeProperties()
+                .Where(x => x.IsMapped())
+                .SingleOrDefault(x => x.IsMapped() && x.GetCustomAttribute<KeyAttribute>() != null);
 
-                if (propInfo != null)
+            if (propertyInfo != null)
+                return propertyInfo;
+
+            foreach (var propertyName in GetDefaultPrimaryKeyNameChecks(entityType))
+            {
+                propertyInfo = entityType.GetTypeInfo().GetDeclaredProperty(propertyName);
+
+                if (propertyInfo != null && propertyInfo.IsMapped())
                 {
-                    return propInfo;
+                    return propertyInfo;
                 }
             }
 
             throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, Resources.EntityRequiresPrimaryKey, entityType));
+        }
+
+        /// <summary>
+        /// Gets the primary key property information for the specified type.
+        /// </summary>
+        /// <returns>The primary key property info.</returns>
+        public static PropertyInfo GetPrimaryKeyPropertyInfo<T>()
+        {
+            return typeof(T).GetPrimaryKeyPropertyInfo();
+        }
+
+        /// <summary>
+        /// Gets the name of the table.
+        /// </summary>
+        /// <param name="entityType">Type of the entity.</param>
+        /// <returns>The name of the table.</returns>
+        public static string GetTableName(this Type entityType)
+        {
+            var tableName = entityType.GetTypeInfo().GetCustomAttribute<TableAttribute>()?.Name;
+
+            if (string.IsNullOrEmpty(tableName))
+                tableName = PluralizationHelper.Pluralize(entityType.Name);
+
+            return tableName;
+        }
+
+        /// <summary>
+        /// Determines whether the specified property is mapped (does not have a <see cref="NotMappedAttribute"/> defined).
+        /// </summary>
+        /// <param name="pi">The property info.</param>
+        /// <returns>
+        ///   <c>true</c> if the property is mapped; otherwise, <c>false</c>.
+        /// </returns>
+        public static bool IsMapped(this PropertyInfo pi)
+        {
+            if (pi == null)
+                throw new ArgumentNullException(nameof(pi));
+
+            return pi.GetCustomAttribute<NotMappedAttribute>() == null;
+        }
+
+        /// <summary>
+        /// Gets the column order for the specified property.
+        /// </summary>
+        /// <param name="pi">The property info.</param>
+        /// <returns>The column order.</returns>
+        public static int GetColumnOrder(this PropertyInfo pi)
+        {
+            if (pi == null)
+                throw new ArgumentNullException(nameof(pi));
+
+            var columnAttribute = pi.GetCustomAttribute<ColumnAttribute>();
+            if (columnAttribute == null)
+                return -1;
+
+            return columnAttribute.Order;
+        }
+
+        /// <summary>
+        /// Gets the name of the foreign key that matches the specified foreign type.
+        /// </summary>
+        /// <param name="sourceType">The source type.</param>
+        /// <param name="foreignType">The foreign type to match.</param>
+        /// <returns>The name of the foreign key.</returns>
+        public static string GetForeignKeyName(this Type sourceType, Type foreignType)
+        {
+            var properties = sourceType.GetRuntimeProperties().Where(x => x.IsMapped());
+            var foreignPropertyInfo = properties.SingleOrDefault(x => x.PropertyType == foreignType);
+            var foreignKeyName = string.Empty;
+
+            if (foreignPropertyInfo != null)
+            {
+                var propertyInfosWithForeignKeys = properties.Where(x => x.GetCustomAttribute<ForeignKeyAttribute>() != null);
+                if (propertyInfosWithForeignKeys.Any())
+                {
+                    // Try to find by checking on the foreign key property
+                    foreignKeyName = propertyInfosWithForeignKeys
+                        .Where(x => x.IsPrimitive())
+                        .SingleOrDefault(x => x.GetCustomAttribute<ForeignKeyAttribute>().Name.Equals(foreignPropertyInfo.Name))
+                        ?.GetColumnName();
+
+                    // Try to find by checking on the navigation property
+                    if (string.IsNullOrEmpty(foreignKeyName))
+                    {
+                        foreignKeyName = properties
+                            .Where(x => x.IsPrimitive())
+                            .SingleOrDefault(x => foreignPropertyInfo.GetCustomAttribute<ForeignKeyAttribute>().Name.Equals(x.GetColumnName()))
+                            ?.GetColumnName();
+                    }
+                }
+
+                // Try to find by naming convention
+                if (string.IsNullOrEmpty(foreignKeyName))
+                {
+                    var foreignPrimaryKeyName = foreignType.GetPrimaryKeyPropertyInfo().GetColumnName();
+
+                    foreignKeyName = properties
+                        .SingleOrDefault(x => x.Name == $"{foreignType.Name}{foreignPrimaryKeyName}")
+                        ?.GetColumnName();
+                }
+            }
+
+            return foreignKeyName;
+        }
+
+        /// <summary>
+        /// Determines if the specified property is a complex type.
+        /// </summary>
+        /// <param name="pi">The property info.</param>
+        /// <returns><c>true</c> if the specified type is a complex type; otherwise, <c>false</c>.</returns>
+        public static bool IsComplex(this PropertyInfo pi)
+        {
+            return pi.PropertyType.Namespace != "System";
+        }
+
+        /// <summary>
+        /// Determines if the specified property is a primitive type.
+        /// </summary>
+        /// <param name="pi">The property info.</param>
+        /// <returns><c>true</c> if the specified type is a primitive type; otherwise, <c>false</c>.</returns>
+        public static bool IsPrimitive(this PropertyInfo pi)
+        {
+            return !IsComplex(pi);
+        }
+
+        /// <summary>
+        /// Gets the name of the column.
+        /// </summary>
+        /// <param name="pi">The property info.</param>
+        /// <returns>The name of the column.</returns>
+        public static string GetColumnName(this PropertyInfo pi)
+        {
+            if (pi == null)
+                throw new ArgumentNullException(nameof(pi));
+
+            // If this is a complex object then don't worry about finding a column attribute for it
+            if (pi.IsComplex())
+                return pi.Name;
+
+            var columnName = pi.GetCustomAttribute<ColumnAttribute>()?.Name;
+
+            if (string.IsNullOrEmpty(columnName))
+                columnName = pi.Name;
+
+            return columnName;
         }
 
         /// <summary>
@@ -71,9 +232,10 @@
         /// <param name="entityType">The entity type to get the primary key from.</param>
         /// <remarks>Assumes the entity has either an 'Id' property or 'EntityName' + 'Id'.</remarks>
         /// <returns>The list of primary key names to check.</returns>
-        private static IEnumerable<string> GetPrimaryKeyNameChecks(Type entityType)
+        private static IEnumerable<string> GetDefaultPrimaryKeyNameChecks(Type entityType)
         {
             const string suffix = "Id";
+
             return new[] { suffix, entityType.Name + suffix };
         }
     }

--- a/src/DotNetToolkit.Repository/Helpers/ExpressionHelper.cs
+++ b/src/DotNetToolkit.Repository/Helpers/ExpressionHelper.cs
@@ -109,6 +109,19 @@
         }
 
         /// <summary>
+        /// Gets the property information.
+        /// </summary>
+        /// <param name="exp">The exp.</param>
+        /// <returns>The property info from the specified expression</returns>
+        public static PropertyInfo GetPropertyInfo(Expression exp)
+        {
+            if (exp == null)
+                throw new ArgumentNullException(nameof(exp));
+
+            return (PropertyInfo)GetMemberExpression(exp)?.Member;
+        }
+
+        /// <summary>
         /// Gets the member expression.
         /// </summary>
         /// <param name="expression">The expression.</param>

--- a/src/DotNetToolkit.Repository/Helpers/PluralizationHelper.cs
+++ b/src/DotNetToolkit.Repository/Helpers/PluralizationHelper.cs
@@ -1,0 +1,152 @@
+﻿namespace DotNetToolkit.Repository.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+
+    internal static class PluralizationHelper
+    {
+        // https://gist.github.com/andrewjk/3186582
+        public static string Pluralize(string text)
+        {
+            var exceptions = GetExceptions();
+            if (exceptions.ContainsKey(text.ToLowerInvariant()))
+                return exceptions[text.ToLowerInvariant()];
+
+            if (text.EndsWith("y", StringComparison.OrdinalIgnoreCase) &&
+                !text.EndsWith("ay", StringComparison.OrdinalIgnoreCase) &&
+                !text.EndsWith("ey", StringComparison.OrdinalIgnoreCase) &&
+                !text.EndsWith("iy", StringComparison.OrdinalIgnoreCase) &&
+                !text.EndsWith("oy", StringComparison.OrdinalIgnoreCase) &&
+                !text.EndsWith("uy", StringComparison.OrdinalIgnoreCase))
+                return text.Substring(0, text.Length - 1) + "ies";
+
+            // http://en.wikipedia.org/wiki/Plural_form_of_words_ending_in_-us
+            if (text.EndsWith("us", StringComparison.CurrentCultureIgnoreCase))
+                return text + "es";
+
+            if (text.EndsWith("ss", StringComparison.CurrentCultureIgnoreCase))
+                return text + "es";
+
+            if (text.EndsWith("s", StringComparison.CurrentCultureIgnoreCase))
+                return text;
+
+            if (text.EndsWith("x", StringComparison.CurrentCultureIgnoreCase) ||
+                text.EndsWith("ch", StringComparison.CurrentCultureIgnoreCase) ||
+                text.EndsWith("sh", StringComparison.CurrentCultureIgnoreCase))
+                return text + "es";
+
+            if (text.EndsWith("f", StringComparison.CurrentCultureIgnoreCase) && text.Length > 1)
+                return text.Substring(0, text.Length - 1) + "ves";
+
+            if (text.EndsWith("fe", StringComparison.CurrentCultureIgnoreCase) && text.Length > 2)
+                return text.Substring(0, text.Length - 2) + "ves";
+
+            return text + "s";
+        }
+
+        private static Dictionary<string, string> GetExceptions()
+        {
+            return new Dictionary<string, string> {
+                { "abyss", "abysses" },
+                { "alumnus", "alumni" },
+                { "analysis", "analyses" },
+                { "aquarium", "aquaria" },
+                { "arch", "arches" },
+                { "atlas", "atlases" },
+                { "axe", "axes" },
+                { "baby", "babies" },
+                { "bacterium", "bacteria" },
+                { "batch", "batches" },
+                { "beach", "beaches" },
+                { "brush", "brushes" },
+                { "bus", "buses" },
+                { "calf", "calves" },
+                { "chateau", "chateaux" },
+                { "cherry", "cherries" },
+                { "child", "children" },
+                { "church", "churches" },
+                { "circus", "circuses" },
+                { "city", "cities" },
+                { "cod", "cod" },
+                { "copy", "copies" },
+                { "crisis", "crises" },
+                { "curriculum", "curricula" },
+                { "deer", "deer" },
+                { "dictionary", "dictionaries" },
+                { "domino", "dominoes" },
+                { "dwarf", "dwarves" },
+                { "echo", "echoes" },
+                { "elf", "elves" },
+                { "emphasis", "emphases" },
+                { "family", "families" },
+                { "fax", "faxes" },
+                { "fish", "fish" },
+                { "flush", "flushes" },
+                { "fly", "flies" },
+                { "foot", "feet" },
+                { "fungus", "fungi" },
+                { "half", "halves" },
+                { "hero", "heroes" },
+                { "hippopotamus", "hippopotami" },
+                { "hoax", "hoaxes" },
+                { "hoof", "hooves" },
+                { "index", "indexes" },
+                { "iris", "irises" },
+                { "kiss", "kisses" },
+                { "knife", "knives" },
+                { "lady", "ladies" },
+                { "leaf", "leaves" },
+                { "life", "lives" },
+                { "loaf", "loaves" },
+                { "man", "men" },
+                { "mango", "mangoes" },
+                { "memorandum", "memoranda" },
+                { "mess", "messes" },
+                { "moose", "moose" },
+                { "motto", "mottoes" },
+                { "mouse", "mice" },
+                { "nanny", "nannies" },
+                { "neurosis", "neuroses" },
+                { "nucleus", "nuclei" },
+                { "oasis", "oases" },
+                { "octopus", "octopi" },
+                { "party", "parties" },
+                { "pass", "passes" },
+                { "penny", "pennies" },
+                { "person", "people" },
+                { "plateau", "plateaux" },
+                { "poppy", "poppies" },
+                { "potato", "potatoes" },
+                { "quiz", "quizzes" },
+                { "reflex", "reflexes" },
+                { "runner-up", "runners-up" },
+                { "scarf", "scarves" },
+                { "scratch", "scratches" },
+                { "series", "series" },
+                { "sheaf", "sheaves" },
+                { "sheep", "sheep" },
+                { "shelf", "shelves" },
+                { "species", "species" },
+                { "splash", "splashes" },
+                { "spy", "spies" },
+                { "stitch", "stitches" },
+                { "story", "stories" },
+                { "syllabus", "syllabi" },
+                { "tax", "taxes" },
+                { "thesis", "theses" },
+                { "thief", "thieves" },
+                { "tomato", "tomatoes" },
+                { "tooth", "teeth" },
+                { "tornado", "tornadoes" },
+                { "try", "tries" },
+                { "volcano", "volcanoes" },
+                { "waltz", "waltzes" },
+                { "wash", "washes" },
+                { "watch", "watches" },
+                { "wharf", "wharves" },
+                { "wife", "wives" },
+                { "woman", "women" }
+            };
+        }
+    }
+}

--- a/src/DotNetToolkit.Repository/Queries/SortingOptions.cs
+++ b/src/DotNetToolkit.Repository/Queries/SortingOptions.cs
@@ -135,7 +135,7 @@
             }
             else
             {
-                var primaryKeyPropertyInfo = ConventionHelper.GetPrimaryKeyPropertyInfo(typeof(T));
+                var primaryKeyPropertyInfo = typeof(T).GetPrimaryKeyPropertyInfo();
                 var primaryKeyPropertyName = primaryKeyPropertyInfo.Name;
 
                 query = IsDescending

--- a/test/DotNetToolkit.Repository.Integration.Test/Data/TestAdoNetConnectionStringFactory.cs
+++ b/test/DotNetToolkit.Repository.Integration.Test/Data/TestAdoNetConnectionStringFactory.cs
@@ -34,7 +34,7 @@
                 {
                     command.CommandType = CommandType.Text;
                     command.Connection = connection;
-                    command.CommandText = @"CREATE TABLE Customer (
+                    command.CommandText = @"CREATE TABLE Customers (
                                             Id int IDENTITY PRIMARY KEY,
                                             Name nvarchar (100),
                                             AddressId int)";
@@ -46,7 +46,7 @@
                 {
                     command.CommandType = CommandType.Text;
                     command.Connection = connection;
-                    command.CommandText = @"CREATE TABLE CustomerAddress (
+                    command.CommandText = @"CREATE TABLE CustomerAddresses (
                                             Id int IDENTITY PRIMARY KEY,
                                             Street nvarchar (100),
                                             City nvarchar (100),


### PR DESCRIPTION
The following data annotations will be supported: 😄 
- [KeyAttribute](https://msdn.microsoft.com/en-us/library/system.componentmodel.dataannotations.keyattribute(v=vs.110).aspx)
- [TableAttribute](https://msdn.microsoft.com/en-us/library/system.componentmodel.dataannotations.schema.tableattribute(v=vs.110).aspx)
- [ForeignKeyAttribute](https://msdn.microsoft.com/en-us/library/system.componentmodel.dataannotations.schema.foreignkeyattribute(v=vs.110).aspx)
- [NotMappedAttribute](https://msdn.microsoft.com/en-us/library/system.componentmodel.dataannotations.schema.notmappedattribute(v=vs.110).aspx)
- [ColumnAttribute](https://msdn.microsoft.com/en-us/library/system.componentmodel.dataannotations.schema.columnattribute(v=vs.110).aspx)

Added support for pluralization of the entity models when mapping to a sql statements. This will take effect when the [TableAttribute.Name](https://msdn.microsoft.com/en-us/library/system.componentmodel.dataannotations.schema.tableattribute.name(v=vs.110).aspx) is not being used.