### PR TITLE
 Renamed the FetchStrategy Include to Fetch

### DIFF
--- a/src/DotNetToolkit.Repository.AdoNet/Internal/AdoNetRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.AdoNet/Internal/AdoNetRepositoryContext.cs
@@ -1431,10 +1431,10 @@
 
             ThrowsIfEntityPrimaryKeyValuesLengthMismatch<TEntity>(keyValues);
 
-            var options = new QueryOptions<TEntity>().SatisfyBy(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues));
+            var options = new QueryOptions<TEntity>().Include(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues));
 
             if (fetchStrategy != null)
-                options.Fetch(fetchStrategy);
+                options.Include(fetchStrategy);
 
             return FindAsync<TEntity, TEntity>(options, IdentityExpression<TEntity>.Instance, cancellationToken);
         }
@@ -1747,10 +1747,10 @@
 
             ThrowsIfEntityPrimaryKeyValuesLengthMismatch<TEntity>(keyValues);
 
-            var options = new QueryOptions<TEntity>().SatisfyBy(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues));
+            var options = new QueryOptions<TEntity>().Include(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues));
 
             if (fetchStrategy != null)
-                options.Fetch(fetchStrategy);
+                options.Include(fetchStrategy);
 
             return Find<TEntity, TEntity>(options, IdentityExpression<TEntity>.Instance);
         }

--- a/src/DotNetToolkit.Repository.AdoNet/Internal/AdoNetRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.AdoNet/Internal/AdoNetRepositoryContext.cs
@@ -1088,7 +1088,7 @@
 
             // Check to see if we can automatically include some navigation properties (this seems to be the behavior of entity framework as well).
             // Only supports a one to one table join for now...
-            if (fetchStrategy == null || !fetchStrategy.IncludePaths.Any())
+            if (fetchStrategy == null || !fetchStrategy.PropertyPaths.Any())
             {
                 // Assumes we want to perform a join when the navigation property from the primary table has also a navigation property of
                 // the same type as the primary table
@@ -1116,13 +1116,13 @@
 
             // Append join tables from fetchStrategy
             // Only supports a one to one table join for now...
-            if (fetchStrategy != null && fetchStrategy.IncludePaths.Any())
+            if (fetchStrategy != null && fetchStrategy.PropertyPaths.Any())
             {
                 var joinStatementSb = new StringBuilder();
 
                 sb.Append($"SELECT\n\t{columns}");
 
-                foreach (var path in fetchStrategy.IncludePaths)
+                foreach (var path in fetchStrategy.PropertyPaths)
                 {
                     var joinTablePropertyInfo = mainTableProperties.Single(x => x.Name.Equals(path));
                     var joinTableType = joinTablePropertyInfo.PropertyType.IsGenericCollection()

--- a/src/DotNetToolkit.Repository.AdoNet/Internal/AdoNetRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.AdoNet/Internal/AdoNetRepositoryContext.cs
@@ -1105,7 +1105,7 @@
 
                     foreach (var path in paths)
                     {
-                        fetchStrategy.Include(path);
+                        fetchStrategy.Fetch(path);
                     }
                 }
             }

--- a/src/DotNetToolkit.Repository.EntityFramework/Internal/EfRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.EntityFramework/Internal/EfRepositoryContext.cs
@@ -59,7 +59,7 @@
         {
             var query = AsQueryable<TEntity>();
 
-            return fetchStrategy == null ? query : fetchStrategy.IncludePaths.Aggregate(query, (current, path) => current.Include(path));
+            return fetchStrategy == null ? query : fetchStrategy.PropertyPaths.Aggregate(query, (current, path) => current.Include(path));
         }
 
         private IQueryable<TEntity> GetQuery<TEntity>(IQueryOptions<TEntity> options) where TEntity : class

--- a/src/DotNetToolkit.Repository.EntityFramework/Internal/EfRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.EntityFramework/Internal/EfRepositoryContext.cs
@@ -168,8 +168,8 @@
             }
 
             var options = new QueryOptions<TEntity>()
-                .SatisfyBy(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues))
-                .Fetch(fetchStrategy);
+                .Include(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues))
+                .Include(fetchStrategy);
 
             return Find<TEntity, TEntity>(options, IdentityExpression<TEntity>.Instance);
         }
@@ -331,8 +331,8 @@
             }
 
             var options = new QueryOptions<TEntity>()
-                .SatisfyBy(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues))
-                .Fetch(fetchStrategy);
+                .Include(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues))
+                .Include(fetchStrategy);
 
             return await FindAsync<TEntity, TEntity>(options, IdentityExpression<TEntity>.Instance, cancellationToken);
         }

--- a/src/DotNetToolkit.Repository.EntityFrameworkCore/Internal/EfCoreRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.EntityFrameworkCore/Internal/EfCoreRepositoryContext.cs
@@ -59,7 +59,7 @@
         {
             var query = AsQueryable<TEntity>();
 
-            return fetchStrategy == null ? query : fetchStrategy.IncludePaths.Aggregate(query, (current, path) => current.Include(path));
+            return fetchStrategy == null ? query : fetchStrategy.PropertyPaths.Aggregate(query, (current, path) => current.Include(path));
         }
 
         private IQueryable<TEntity> GetQuery<TEntity>(IQueryOptions<TEntity> options) where TEntity : class

--- a/src/DotNetToolkit.Repository.EntityFrameworkCore/Internal/EfCoreRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.EntityFrameworkCore/Internal/EfCoreRepositoryContext.cs
@@ -168,8 +168,8 @@
             }
 
             var options = new QueryOptions<TEntity>()
-                .SatisfyBy(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues))
-                .Fetch(fetchStrategy);
+                .Include(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues))
+                .Include(fetchStrategy);
 
             return Find<TEntity, TEntity>(options, IdentityExpression<TEntity>.Instance);
         }
@@ -331,8 +331,8 @@
             }
 
             var options = new QueryOptions<TEntity>()
-                .SatisfyBy(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues))
-                .Fetch(fetchStrategy);
+                .Include(PrimaryKeyConventionHelper.GetByPrimaryKeySpecification<TEntity>(keyValues))
+                .Include(fetchStrategy);
 
             return await FindAsync<TEntity, TEntity>(options, IdentityExpression<TEntity>.Instance, cancellationToken);
         }

--- a/src/DotNetToolkit.Repository/Queries/QueryOptions.cs
+++ b/src/DotNetToolkit.Repository/Queries/QueryOptions.cs
@@ -183,7 +183,7 @@
 
             _fetchStrategy = _fetchStrategy ?? new FetchQueryStrategy<T>();
 
-            mergedPaths.ForEach(path => _fetchStrategy.Include(path));
+            mergedPaths.ForEach(path => _fetchStrategy.Fetch(path));
 
             return this;
         }
@@ -200,7 +200,7 @@
 
             _fetchStrategy = _fetchStrategy ?? new FetchQueryStrategy<T>();
 
-            _fetchStrategy.Include(path);
+            _fetchStrategy.Fetch(path);
 
             return this;
         }

--- a/src/DotNetToolkit.Repository/Queries/QueryOptions.cs
+++ b/src/DotNetToolkit.Repository/Queries/QueryOptions.cs
@@ -135,11 +135,11 @@
         }
 
         /// <summary>
-        /// Applies a criteria that is used for matching entities against and combine it with the current specified predicate using the logical "and".
+        /// Includes a specification strategy/criteria that is used for matching entities against and combine it with the current specified predicate using the logical "and".
         /// </summary>
         /// <param name="criteria">The specification criteria that is used for matching entities against.</param>
         /// <returns>The current instance.</returns>
-        public QueryOptions<T> SatisfyBy(ISpecificationQueryStrategy<T> criteria)
+        public QueryOptions<T> Include(ISpecificationQueryStrategy<T> criteria)
         {
             if (criteria == null)
                 throw new ArgumentNullException(nameof(criteria));
@@ -169,11 +169,11 @@
         }
 
         /// <summary>
-        /// Applies the fetch strategy which defines the child objects that should be retrieved when loading the entity.
+        /// Includes the fetch strategy which defines the child objects that should be retrieved when loading the entity and combines it with the current property pahts collection.
         /// </summary>
         /// <param name="fetchStrategy">The fetch strategy.</param>
         /// <returns>The current instance.</returns>
-        public QueryOptions<T> Fetch(IFetchQueryStrategy<T> fetchStrategy)
+        public QueryOptions<T> Include(IFetchQueryStrategy<T> fetchStrategy)
         {
             if (fetchStrategy == null)
                 throw new ArgumentNullException(nameof(fetchStrategy));

--- a/src/DotNetToolkit.Repository/Queries/QueryOptions.cs
+++ b/src/DotNetToolkit.Repository/Queries/QueryOptions.cs
@@ -178,8 +178,8 @@
             if (fetchStrategy == null)
                 throw new ArgumentNullException(nameof(fetchStrategy));
 
-            var paths = _fetchStrategy != null ? ((IFetchQueryStrategy<T>)_fetchStrategy).IncludePaths : new List<string>();
-            var mergedPaths = paths.Union(fetchStrategy.IncludePaths).ToList();
+            var paths = _fetchStrategy != null ? ((IFetchQueryStrategy<T>)_fetchStrategy).PropertyPaths : new List<string>();
+            var mergedPaths = paths.Union(fetchStrategy.PropertyPaths).ToList();
 
             _fetchStrategy = _fetchStrategy ?? new FetchQueryStrategy<T>();
 

--- a/src/DotNetToolkit.Repository/Queries/Strategies/FetchQueryStrategy.cs
+++ b/src/DotNetToolkit.Repository/Queries/Strategies/FetchQueryStrategy.cs
@@ -43,9 +43,9 @@
         /// </summary>
         /// <param name="path">A lambda expression representing the path to include.</param>
         /// <returns>A new <see cref="IFetchQueryStrategy{T}" /> with the defined query path.</returns>
-        public IFetchQueryStrategy<T> Include(Expression<Func<T, object>> path)
+        public IFetchQueryStrategy<T> Fetch(Expression<Func<T, object>> path)
         {
-            return Include(path.ToIncludeString());
+            return Fetch(path.ToIncludeString());
         }
 
         /// <summary>
@@ -53,7 +53,7 @@
         /// </summary>
         /// <param name="path">The dot-separated list of related objects to return in the query results.</param>
         /// <returns>A new <see cref="IFetchQueryStrategy{T}" /> with the defined query path.</returns>
-        public IFetchQueryStrategy<T> Include(string path)
+        public IFetchQueryStrategy<T> Fetch(string path)
         {
             _properties.Add(path);
             return this;

--- a/src/DotNetToolkit.Repository/Queries/Strategies/FetchQueryStrategy.cs
+++ b/src/DotNetToolkit.Repository/Queries/Strategies/FetchQueryStrategy.cs
@@ -33,7 +33,7 @@
         /// <summary>
         /// Gets the collection of related objects to include in the query results.
         /// </summary>
-        IEnumerable<string> IFetchQueryStrategy<T>.IncludePaths
+        IEnumerable<string> IFetchQueryStrategy<T>.PropertyPaths
         {
             get { return _properties; }
         }

--- a/src/DotNetToolkit.Repository/Queries/Strategies/IFetchQueryStrategy.cs
+++ b/src/DotNetToolkit.Repository/Queries/Strategies/IFetchQueryStrategy.cs
@@ -20,13 +20,13 @@
         /// </summary>
         /// <param name="path">A lambda expression representing the path to include.</param>
         /// <returns>A new <see cref="IFetchQueryStrategy{T}" /> with the defined query path.</returns>
-        IFetchQueryStrategy<T> Include(Expression<Func<T, object>> path);
+        IFetchQueryStrategy<T> Fetch(Expression<Func<T, object>> path);
 
         /// <summary>
         /// Specifies the related objects to include in the query results.
         /// </summary>
         /// <param name="path">The dot-separated list of related objects to return in the query results.</param>
         /// <returns>A new <see cref="IFetchQueryStrategy{T}" /> with the defined query path.</returns>
-        IFetchQueryStrategy<T> Include(string path);
+        IFetchQueryStrategy<T> Fetch(string path);
     }
 }

--- a/src/DotNetToolkit.Repository/Queries/Strategies/IFetchQueryStrategy.cs
+++ b/src/DotNetToolkit.Repository/Queries/Strategies/IFetchQueryStrategy.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// Gets the collection of related objects to include in the query results.
         /// </summary>
-        IEnumerable<string> IncludePaths { get; }
+        IEnumerable<string> PropertyPaths { get; }
 
         /// <summary>
         /// Specifies the related objects to include in the query results.

--- a/test/DotNetToolkit.Repository.Integration.Test/AdoNetRepositoryTests.cs
+++ b/test/DotNetToolkit.Repository.Integration.Test/AdoNetRepositoryTests.cs
@@ -515,7 +515,7 @@
 
             var addressRepo = new Repository<CustomerAddressWithMultipleAddresses>(context);
             var customerRepo = new Repository<CustomerWithMultipleAddresses>(context);
-            var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Include(x => x.Addresses);
+            var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Fetch(x => x.Addresses);
             var options = new QueryOptions<CustomerWithMultipleAddresses>();
             var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Fetch(customerFetchStrategy);
 
@@ -561,7 +561,7 @@
 
             var addressRepo = new Repository<CustomerAddressWithMultipleAddresses>(context);
             var customerRepo = new Repository<CustomerWithMultipleAddresses>(context);
-            var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Include(x => x.Addresses);
+            var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Fetch(x => x.Addresses);
             var options = new QueryOptions<CustomerWithMultipleAddresses>();
             var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Fetch(customerFetchStrategy);
 
@@ -607,7 +607,7 @@
 
             var addressRepo = new Repository<CustomerAddressWithMultipleAddresses>(context);
             var customerRepo = new Repository<CustomerWithMultipleAddresses>(context);
-            var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Include(x => x.Addresses);
+            var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Fetch(x => x.Addresses);
             var options = new QueryOptions<CustomerWithMultipleAddresses>();
             var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Fetch(customerFetchStrategy);
 
@@ -655,7 +655,7 @@
 
             var addressRepo = new Repository<CustomerAddressWithMultipleAddresses>(context);
             var customerRepo = new Repository<CustomerWithMultipleAddresses>(context);
-            var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Include(x => x.Addresses);
+            var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Fetch(x => x.Addresses);
             var options = new QueryOptions<CustomerWithMultipleAddresses>();
             var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Fetch(customerFetchStrategy);
 

--- a/test/DotNetToolkit.Repository.Integration.Test/AdoNetRepositoryTests.cs
+++ b/test/DotNetToolkit.Repository.Integration.Test/AdoNetRepositoryTests.cs
@@ -517,7 +517,7 @@
             var customerRepo = new Repository<CustomerWithMultipleAddresses>(context);
             var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Fetch(x => x.Addresses);
             var options = new QueryOptions<CustomerWithMultipleAddresses>();
-            var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Fetch(customerFetchStrategy);
+            var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Include(customerFetchStrategy);
 
             var entity = new CustomerWithMultipleAddresses
             {
@@ -563,7 +563,7 @@
             var customerRepo = new Repository<CustomerWithMultipleAddresses>(context);
             var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Fetch(x => x.Addresses);
             var options = new QueryOptions<CustomerWithMultipleAddresses>();
-            var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Fetch(customerFetchStrategy);
+            var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Include(customerFetchStrategy);
 
             var entity = new CustomerWithMultipleAddresses
             {
@@ -609,7 +609,7 @@
             var customerRepo = new Repository<CustomerWithMultipleAddresses>(context);
             var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Fetch(x => x.Addresses);
             var options = new QueryOptions<CustomerWithMultipleAddresses>();
-            var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Fetch(customerFetchStrategy);
+            var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Include(customerFetchStrategy);
 
             var customerKey = 1;
 
@@ -657,7 +657,7 @@
             var customerRepo = new Repository<CustomerWithMultipleAddresses>(context);
             var customerFetchStrategy = new FetchQueryStrategy<CustomerWithMultipleAddresses>().Fetch(x => x.Addresses);
             var options = new QueryOptions<CustomerWithMultipleAddresses>();
-            var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Fetch(customerFetchStrategy);
+            var optionsWithFetchStrategy = new QueryOptions<CustomerWithMultipleAddresses>().Include(customerFetchStrategy);
 
             var customerKey = 1;
 

--- a/test/DotNetToolkit.Repository.Integration.Test/RepositoryTraitsTests.cs
+++ b/test/DotNetToolkit.Repository.Integration.Test/RepositoryTraitsTests.cs
@@ -811,7 +811,7 @@
             const string name = "Random Name";
 
             var fetchStrategy = new FetchQueryStrategy<Customer>();
-            fetchStrategy.Include(x => x.Address);
+            fetchStrategy.Fetch(x => x.Address);
 
             var entity = new Customer { Id = key, Name = name };
 
@@ -1860,7 +1860,7 @@
             const string name = "Random Name";
 
             var fetchStrategy = new FetchQueryStrategy<Customer>();
-            fetchStrategy.Include(x => x.Address);
+            fetchStrategy.Fetch(x => x.Address);
 
             var entity = new Customer { Id = key, Name = name };
 

--- a/test/DotNetToolkit.Repository.Test/FetchStrategyTests.cs
+++ b/test/DotNetToolkit.Repository.Test/FetchStrategyTests.cs
@@ -14,9 +14,9 @@
                 .Fetch(x => x.Phone)
                 .Fetch(x => x.Phone.Customer);
 
-            Assert.Contains("Address", strategy.IncludePaths);
-            Assert.Contains("Phone", strategy.IncludePaths);
-            Assert.Contains("Phone.Customer", strategy.IncludePaths);
+            Assert.Contains("Address", strategy.PropertyPaths);
+            Assert.Contains("Phone", strategy.PropertyPaths);
+            Assert.Contains("Phone.Customer", strategy.PropertyPaths);
         }
 
         [Fact]
@@ -27,9 +27,9 @@
                 .Fetch("Phone")
                 .Fetch("Phone.Customer");
 
-            Assert.Contains("Address", strategy.IncludePaths);
-            Assert.Contains("Phone", strategy.IncludePaths);
-            Assert.Contains("Phone.Customer", strategy.IncludePaths);
+            Assert.Contains("Address", strategy.PropertyPaths);
+            Assert.Contains("Phone", strategy.PropertyPaths);
+            Assert.Contains("Phone.Customer", strategy.PropertyPaths);
         }
     }
 }

--- a/test/DotNetToolkit.Repository.Test/FetchStrategyTests.cs
+++ b/test/DotNetToolkit.Repository.Test/FetchStrategyTests.cs
@@ -7,12 +7,12 @@
     public class FetchStrategyTests
     {
         [Fact]
-        public void Include()
+        public void Fetch()
         {
             var strategy = new FetchQueryStrategy<Customer>()
-                .Include(x => x.Address)
-                .Include(x => x.Phone)
-                .Include(x => x.Phone.Customer);
+                .Fetch(x => x.Address)
+                .Fetch(x => x.Phone)
+                .Fetch(x => x.Phone.Customer);
 
             Assert.Contains("Address", strategy.IncludePaths);
             Assert.Contains("Phone", strategy.IncludePaths);
@@ -20,12 +20,12 @@
         }
 
         [Fact]
-        public void Include_Property_Names()
+        public void Fetch_Property_Names()
         {
             var strategy = new FetchQueryStrategy<Customer>()
-                .Include("Address")
-                .Include("Phone")
-                .Include("Phone.Customer");
+                .Fetch("Address")
+                .Fetch("Phone")
+                .Fetch("Phone.Customer");
 
             Assert.Contains("Address", strategy.IncludePaths);
             Assert.Contains("Phone", strategy.IncludePaths);

--- a/test/DotNetToolkit.Repository.Test/QueryOptionsTests.cs
+++ b/test/DotNetToolkit.Repository.Test/QueryOptionsTests.cs
@@ -143,8 +143,8 @@
             var firstSpec = new SpecificationQueryStrategy<Customer>(x => x.Name.Equals("Random Name"));
             var secondSpec = new SpecificationQueryStrategy<Customer>(x => x.Id == 1);
             var options = new QueryOptions<Customer>()
-                .SatisfyBy(firstSpec)
-                .SatisfyBy(secondSpec);
+                .Include(firstSpec)
+                .Include(secondSpec);
 
             Assert.Equal(firstSpec.And(secondSpec).Predicate.ToString(), ((IQueryOptions<Customer>)options).SpecificationStrategy.Predicate.ToString());
         }
@@ -162,8 +162,8 @@
             Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
 
             options = new QueryOptions<Customer>()
-                .Fetch(new FetchQueryStrategy<Customer>().Fetch("Address"))
-                .Fetch(new FetchQueryStrategy<Customer>().Fetch("Phone"))
+                .Include(new FetchQueryStrategy<Customer>().Fetch("Address"))
+                .Include(new FetchQueryStrategy<Customer>().Fetch("Phone"))
                 .Fetch("Phone.Customer");
 
             Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
@@ -184,8 +184,8 @@
             Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
 
             options = new QueryOptions<Customer>()
-                .Fetch(new FetchQueryStrategy<Customer>().Fetch(x => x.Address))
-                .Fetch(new FetchQueryStrategy<Customer>().Fetch(x => x.Phone))
+                .Include(new FetchQueryStrategy<Customer>().Fetch(x => x.Address))
+                .Include(new FetchQueryStrategy<Customer>().Fetch(x => x.Phone))
                 .Fetch(x => x.Phone.Customer);
 
             Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);

--- a/test/DotNetToolkit.Repository.Test/QueryOptionsTests.cs
+++ b/test/DotNetToolkit.Repository.Test/QueryOptionsTests.cs
@@ -157,18 +157,18 @@
                 .Fetch("Phone")
                 .Fetch("Phone.Customer");
 
-            Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
-            Assert.Contains("Phone", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
-            Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
+            Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
+            Assert.Contains("Phone", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
+            Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
 
             options = new QueryOptions<Customer>()
                 .Fetch(new FetchQueryStrategy<Customer>().Fetch("Address"))
                 .Fetch(new FetchQueryStrategy<Customer>().Fetch("Phone"))
                 .Fetch("Phone.Customer");
 
-            Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
-            Assert.Contains("Phone", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
-            Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
+            Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
+            Assert.Contains("Phone", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
+            Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
         }
 
         [Fact]
@@ -179,18 +179,18 @@
                 .Fetch(x => x.Phone)
                 .Fetch(x => x.Phone.Customer);
 
-            Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
-            Assert.Contains("Phone", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
-            Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
+            Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
+            Assert.Contains("Phone", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
+            Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
 
             options = new QueryOptions<Customer>()
                 .Fetch(new FetchQueryStrategy<Customer>().Fetch(x => x.Address))
                 .Fetch(new FetchQueryStrategy<Customer>().Fetch(x => x.Phone))
                 .Fetch(x => x.Phone.Customer);
 
-            Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
-            Assert.Contains("Phone", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
-            Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
+            Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
+            Assert.Contains("Phone", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
+            Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.PropertyPaths);
         }
     }
 }

--- a/test/DotNetToolkit.Repository.Test/QueryOptionsTests.cs
+++ b/test/DotNetToolkit.Repository.Test/QueryOptionsTests.cs
@@ -162,8 +162,8 @@
             Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
 
             options = new QueryOptions<Customer>()
-                .Fetch(new FetchQueryStrategy<Customer>().Include("Address"))
-                .Fetch(new FetchQueryStrategy<Customer>().Include("Phone"))
+                .Fetch(new FetchQueryStrategy<Customer>().Fetch("Address"))
+                .Fetch(new FetchQueryStrategy<Customer>().Fetch("Phone"))
                 .Fetch("Phone.Customer");
 
             Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
@@ -184,8 +184,8 @@
             Assert.Contains("Phone.Customer", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);
 
             options = new QueryOptions<Customer>()
-                .Fetch(new FetchQueryStrategy<Customer>().Include(x => x.Address))
-                .Fetch(new FetchQueryStrategy<Customer>().Include(x => x.Phone))
+                .Fetch(new FetchQueryStrategy<Customer>().Fetch(x => x.Address))
+                .Fetch(new FetchQueryStrategy<Customer>().Fetch(x => x.Phone))
                 .Fetch(x => x.Phone.Customer);
 
             Assert.Contains("Address", ((IQueryOptions<Customer>)options).FetchStrategy.IncludePaths);


### PR DESCRIPTION
Closes #216 

Additionally:
- Renamed the IncludePaths in the IFetchStrategy to PropertyPaths
- Renamed the Fetch and SatisfyBy in the query options to in Include