### PR TITLE
Ensured properties have a public setter before performing any mapping in ado.net

### DIFF
--- a/src/DotNetToolkit.Repository/Configuration/Conventions/ModelConventionHelper.cs
+++ b/src/DotNetToolkit.Repository/Configuration/Conventions/ModelConventionHelper.cs
@@ -53,10 +53,12 @@
             if (pi == null)
                 throw new ArgumentNullException(nameof(pi));
 
-            return pi.GetCustomAttribute<NotMappedAttribute>() == null;
+            if (pi.GetCustomAttribute<NotMappedAttribute>() != null)
+                return false;
+
+            // Ensures the property has public setter
+            return pi.CanWrite && pi.GetSetMethod(nonPublic: true).IsPublic;
         }
-
-
 
         /// <summary>
         /// Gets the name of the column.


### PR DESCRIPTION
Closes #208 