### PR TITLE
Added a new parameter to the ado.net context to optionally create/validate the database context

### DIFF
--- a/src/DotNetToolkit.Repository.AdoNet/Internal/AdoNetRepositoryContextFactory.cs
+++ b/src/DotNetToolkit.Repository.AdoNet/Internal/AdoNetRepositoryContextFactory.cs
@@ -17,6 +17,7 @@
         private readonly string _nameOrConnectionString;
         private readonly string _providerName;
         private readonly DbConnection _existingConnection;
+        private readonly bool _ensureDatabaseCreated;
 
         #endregion
 
@@ -26,12 +27,18 @@
         /// Initializes a new instance of the <see cref="AdoNetRepositoryContextFactory"/> class.
         /// </summary>
         /// <param name="nameOrConnectionString">Either the database name or a connection string.</param>
-        public AdoNetRepositoryContextFactory(string nameOrConnectionString)
+        /// <param name="ensureDatabaseCreated">
+        /// Ensures that the database for the context exists. If it exists, no action is taken.
+        /// If it does not exist then the database and all its schema are created.
+        /// If the database exists, then no effort is made to ensure it is compatible with the model for this context.
+        /// </param>
+        public AdoNetRepositoryContextFactory(string nameOrConnectionString, bool ensureDatabaseCreated = false)
         {
             if (nameOrConnectionString == null)
                 throw new ArgumentNullException(nameof(nameOrConnectionString));
 
             _nameOrConnectionString = nameOrConnectionString;
+            _ensureDatabaseCreated = ensureDatabaseCreated;
         }
 
         /// <summary>
@@ -39,7 +46,12 @@
         /// </summary>
         /// <param name="providerName">The name of the provider.</param>
         /// <param name="connectionString">The connection string.</param>
-        public AdoNetRepositoryContextFactory(string providerName, string connectionString)
+        /// <param name="ensureDatabaseCreated">
+        /// Ensures that the database for the context exists. If it exists, no action is taken.
+        /// If it does not exist then the database and all its schema are created.
+        /// If the database exists, then no effort is made to ensure it is compatible with the model for this context.
+        /// </param>
+        public AdoNetRepositoryContextFactory(string providerName, string connectionString, bool ensureDatabaseCreated = false)
         {
             if (providerName == null)
                 throw new ArgumentNullException(nameof(providerName));
@@ -49,13 +61,19 @@
 
             _providerName = providerName;
             _nameOrConnectionString = connectionString;
+            _ensureDatabaseCreated = ensureDatabaseCreated;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AdoNetRepositoryContextFactory" /> class.
         /// </summary>
         /// <param name="existingConnection">The existing connection.</param>
-        public AdoNetRepositoryContextFactory(DbConnection existingConnection)
+        /// <param name="ensureDatabaseCreated">
+        /// Ensures that the database for the context exists. If it exists, no action is taken.
+        /// If it does not exist then the database and all its schema are created.
+        /// If the database exists, then no effort is made to ensure it is compatible with the model for this context.
+        /// </param>
+        public AdoNetRepositoryContextFactory(DbConnection existingConnection, bool ensureDatabaseCreated = false)
         {
             if (existingConnection == null)
                 throw new ArgumentNullException(nameof(existingConnection));
@@ -64,6 +82,7 @@
                 existingConnection.Open();
 
             _existingConnection = existingConnection;
+            _ensureDatabaseCreated = ensureDatabaseCreated;
         }
 
         #endregion
@@ -77,12 +96,12 @@
         public IRepositoryContext Create()
         {
             if (_existingConnection != null)
-                return new AdoNetRepositoryContext(_existingConnection);
+                return new AdoNetRepositoryContext(_existingConnection, _ensureDatabaseCreated);
 
             if (!string.IsNullOrEmpty(_providerName))
-                return new AdoNetRepositoryContext(_providerName, _nameOrConnectionString);
+                return new AdoNetRepositoryContext(_providerName, _nameOrConnectionString, _ensureDatabaseCreated);
 
-            return new AdoNetRepositoryContext(_nameOrConnectionString);
+            return new AdoNetRepositoryContext(_nameOrConnectionString, _ensureDatabaseCreated);
         }
 
         #endregion

--- a/src/DotNetToolkit.Repository.AdoNet/RepositoryOptionsBuilderExtensions.cs
+++ b/src/DotNetToolkit.Repository.AdoNet/RepositoryOptionsBuilderExtensions.cs
@@ -15,8 +15,13 @@
         /// </summary>
         /// <param name="source">The repository options builder.</param>
         /// <param name="nameOrConnectionString">Either the database name or a connection string.</param>
+        /// <param name="ensureDatabaseCreated">
+        /// Ensures that the database for the context exists. If it exists, no action is taken.
+        /// If it does not exist then the database and all its schema are created.
+        /// If the database exists, then no effort is made to ensure it is compatible with the model for this context.
+        /// </param>
         /// <returns>The same builder instance.</returns>
-        public static RepositoryOptionsBuilder UseAdoNet(this RepositoryOptionsBuilder source, string nameOrConnectionString)
+        public static RepositoryOptionsBuilder UseAdoNet(this RepositoryOptionsBuilder source, string nameOrConnectionString, bool ensureDatabaseCreated = false)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -24,7 +29,7 @@
             if (nameOrConnectionString == null)
                 throw new ArgumentNullException(nameof(nameOrConnectionString));
 
-            source.UseInternalContextFactory(new AdoNetRepositoryContextFactory(nameOrConnectionString));
+            source.UseInternalContextFactory(new AdoNetRepositoryContextFactory(nameOrConnectionString, ensureDatabaseCreated));
 
             return source;
         }
@@ -35,8 +40,13 @@
         /// <param name="source">The repository options builder.</param>
         /// <param name="providerName">The name of the provider.</param>
         /// <param name="connectionString">The connection string.</param>
+        /// <param name="ensureDatabaseCreated">
+        /// Ensures that the database for the context exists. If it exists, no action is taken.
+        /// If it does not exist then the database and all its schema are created.
+        /// If the database exists, then no effort is made to ensure it is compatible with the model for this context.
+        /// </param>
         /// <returns>The same builder instance.</returns>
-        public static RepositoryOptionsBuilder UseAdoNet(this RepositoryOptionsBuilder source, string providerName, string connectionString)
+        public static RepositoryOptionsBuilder UseAdoNet(this RepositoryOptionsBuilder source, string providerName, string connectionString, bool ensureDatabaseCreated = false)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -47,7 +57,7 @@
             if (connectionString == null)
                 throw new ArgumentNullException(nameof(connectionString));
 
-            source.UseInternalContextFactory(new AdoNetRepositoryContextFactory(providerName, connectionString));
+            source.UseInternalContextFactory(new AdoNetRepositoryContextFactory(providerName, connectionString, ensureDatabaseCreated));
 
             return source;
         }
@@ -57,8 +67,13 @@
         /// </summary>
         /// <param name="source">The repository options builder.</param>
         /// <param name="existingConnection">The existing connection.</param>
+        /// <param name="ensureDatabaseCreated">
+        /// Ensures that the database for the context exists. If it exists, no action is taken.
+        /// If it does not exist then the database and all its schema are created.
+        /// If the database exists, then no effort is made to ensure it is compatible with the model for this context.
+        /// </param>
         /// <returns>The same builder instance.</returns>
-        public static RepositoryOptionsBuilder UseAdoNet(this RepositoryOptionsBuilder source, DbConnection existingConnection)
+        public static RepositoryOptionsBuilder UseAdoNet(this RepositoryOptionsBuilder source, DbConnection existingConnection, bool ensureDatabaseCreated = false)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
@@ -66,7 +81,7 @@
             if (existingConnection == null)
                 throw new ArgumentNullException(nameof(existingConnection));
 
-            source.UseInternalContextFactory(new AdoNetRepositoryContextFactory(existingConnection));
+            source.UseInternalContextFactory(new AdoNetRepositoryContextFactory(existingConnection, ensureDatabaseCreated));
 
             return source;
         }

--- a/test/DotNetToolkit.Repository.Integration.Test/Data/TestBase.cs
+++ b/test/DotNetToolkit.Repository.Integration.Test/Data/TestBase.cs
@@ -139,7 +139,7 @@ namespace DotNetToolkit.Repository.Integration.Test.Data
                     }
                 case ContextProviderType.AdoNet:
                     {
-                        builder.UseAdoNet(TestDbConnectionHelper.CreateConnection());
+                        builder.UseAdoNet(TestDbConnectionHelper.CreateConnection(), ensureDatabaseCreated: true);
                         break;
                     }
                 case ContextProviderType.EntityFramework:


### PR DESCRIPTION
Closes #383 

This new parameter will be set to false by default. Which means that the user will need to maintain the database unless it is set to true.