### PR TITLE
Allow net451, netstandard1.3 to use configuration sections

### DIFF
--- a/src/DotNetToolkit.Repository/Configuration/Options/RepositoryOptionsBuilder.cs
+++ b/src/DotNetToolkit.Repository/Configuration/Options/RepositoryOptionsBuilder.cs
@@ -94,7 +94,6 @@
         }
 #endif
 
-#if NETSTANDARD2_0
         /// <summary>
         /// Configures the repository options using the specified configuration.
         /// </summary>
@@ -120,7 +119,6 @@
 
             return this;
         }
-#endif
 
         /// <summary>
         /// Configures the repository options with an interceptor that intercepts any activity within the repository.

--- a/src/DotNetToolkit.Repository/DotNetToolkit.Repository.csproj
+++ b/src/DotNetToolkit.Repository/DotNetToolkit.Repository.csproj
@@ -29,11 +29,13 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
     <Reference Include="System.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="1.1.2" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
   </ItemGroup>

--- a/src/DotNetToolkit.Repository/Internal/ConfigFile/ConfigurationHandler.cs
+++ b/src/DotNetToolkit.Repository/Internal/ConfigFile/ConfigurationHandler.cs
@@ -1,6 +1,4 @@
-﻿#if NETSTANDARD2_0
-
-namespace DotNetToolkit.Repository.Internal.ConfigFile
+﻿namespace DotNetToolkit.Repository.Internal.ConfigFile
 {
     using Configuration.Interceptors;
     using Factories;
@@ -147,5 +145,3 @@ namespace DotNetToolkit.Repository.Internal.ConfigFile
         #endregion
     }
 }
-
-#endif

--- a/src/DotNetToolkit.Repository/Internal/ConfigFile/ConfigurationHandler.cs
+++ b/src/DotNetToolkit.Repository/Internal/ConfigFile/ConfigurationHandler.cs
@@ -17,9 +17,7 @@
         private const string RepositorySectionKey = "repository";
         private const string DefaultContextFactorySectionKey = "defaultContextFactory";
         private const string InterceptorCollectionSectionKey = "interceptors";
-        private const string InterceptorSectionKey = "interceptor";
         private const string ParameterCollectionSectionKey = "parameters";
-        private const string ParameterSectionKey = "parameter";
         private const string ValueKey = "value";
         private const string TypeKey = "type";
 
@@ -48,26 +46,18 @@
 
             if (defaultContextFactorySection != null)
             {
+                if (defaultContextFactorySection[TypeKey] == null)
+                    throw new InvalidOperationException($"The '{TypeKey}' is missing for this interceptor section.");
+
+                var contextFactoryType = Type.GetType(defaultContextFactorySection[TypeKey], throwOnError: true);
+
                 var parameterCollectionSection = defaultContextFactorySection.GetSection(ParameterCollectionSectionKey);
                 var args = new List<object>();
 
                 if (parameterCollectionSection != null)
                 {
-                    foreach (var parameterCollectionSectionChildren in parameterCollectionSection.GetChildren())
-                    {
-                        var parameterSection = parameterCollectionSectionChildren.GetSection(ParameterSectionKey);
-
-                        if (parameterSection != null)
-                        {
-                            var parameterType = Type.GetType(parameterSection[TypeKey], throwOnError: true);
-                            var parameterValue = Convert.ChangeType(parameterSection[ValueKey], parameterType, CultureInfo.InvariantCulture);
-
-                            args.Add(parameterValue);
-                        }
-                    }
+                    args.AddRange(parameterCollectionSection.GetChildren().Select(ExtractParameterValue));
                 }
-
-                var contextFactoryType = Type.GetType(defaultContextFactorySection[TypeKey], throwOnError: true);
 
                 return CreateInstance<IRepositoryContextFactory>(contextFactoryType, args.ToArray());
             }
@@ -84,10 +74,8 @@
             {
                 var defaultFactory = RepositoryInterceptorProvider.GetDefaultFactory();
 
-                foreach (var interceptorCollectionSectionChildren in interceptorCollectionSection.GetChildren())
+                foreach (var interceptorSection in interceptorCollectionSection.GetChildren())
                 {
-                    var interceptorSection = interceptorCollectionSectionChildren.GetSection(InterceptorSectionKey);
-
                     if (interceptorSection != null)
                     {
                         var interceptorType = Type.GetType(interceptorSection[TypeKey], throwOnError: true);
@@ -102,18 +90,7 @@
 
                             if (parameterCollectionSection != null)
                             {
-                                foreach (var parameterCollectionSectionChildren in parameterCollectionSection.GetChildren())
-                                {
-                                    var parameterSection = parameterCollectionSectionChildren.GetSection(ParameterSectionKey);
-
-                                    if (parameterSection != null)
-                                    {
-                                        var parameterType = Type.GetType(parameterSection[TypeKey], throwOnError: true);
-                                        var parameterValue = Convert.ChangeType(parameterSection[ValueKey], parameterType, CultureInfo.InvariantCulture);
-
-                                        args.Add(parameterValue);
-                                    }
-                                }
+                                args.AddRange(parameterCollectionSection.GetChildren().Select(ExtractParameterValue));
                             }
 
                             return CreateInstance<IRepositoryInterceptor>(interceptorType, args.ToArray());
@@ -125,6 +102,20 @@
             }
 
             return interceptorsDict;
+        }
+
+        private static object ExtractParameterValue(IConfigurationSection parameterSection)
+        {
+            if (parameterSection[TypeKey] == null)
+                throw new InvalidOperationException($"The '{TypeKey}' is missing for this parameter section.");
+
+            if (parameterSection[ValueKey] == null)
+                throw new InvalidOperationException($"The '{ValueKey}' is missing for this parameter section.");
+
+            var parameterType = Type.GetType(parameterSection[TypeKey], throwOnError: true);
+            var parameterValue = Convert.ChangeType(parameterSection[ValueKey], parameterType, CultureInfo.InvariantCulture);
+
+            return parameterValue;
         }
 
         #endregion

--- a/src/DotNetToolkit.Repository/Internal/ConfigFile/RepositoryInterceptorProvider.cs
+++ b/src/DotNetToolkit.Repository/Internal/ConfigFile/RepositoryInterceptorProvider.cs
@@ -1,6 +1,4 @@
-﻿#if !NETSTANDARD1_3
-
-namespace DotNetToolkit.Repository.Internal.ConfigFile
+﻿namespace DotNetToolkit.Repository.Internal.ConfigFile
 {
     using System;
 
@@ -31,5 +29,3 @@ namespace DotNetToolkit.Repository.Internal.ConfigFile
         }
     }
 }
-
-#endif

--- a/test/DotNetToolkit.Repository.Integration.Test/DotNetToolkit.Repository.Integration.Test.csproj
+++ b/test/DotNetToolkit.Repository.Integration.Test/DotNetToolkit.Repository.Integration.Test.csproj
@@ -17,12 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="EntityFramework.SqlServerCompact" Version="6.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />

--- a/test/DotNetToolkit.Repository.Test/App.config
+++ b/test/DotNetToolkit.Repository.Test/App.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="repository" type="DotNetToolkit.Repository.Internal.ConfigFile.ConfigurationSection, DotNetToolkit.Repository" />
+  </configSections>
+  <repository>
+    <defaultContextFactory type="DotNetToolkit.Repository.InMemory.Internal.InMemoryRepositoryContextFactory, DotNetToolkit.Repository.InMemory" />
+    <interceptors>
+      <interceptor type="DotNetToolkit.Repository.Test.Data.TestRepositoryInterceptor, DotNetToolkit.Repository.Test">
+        <parameters>
+          <parameter value="random param" />
+          <parameter value="True" type="System.Boolean" />
+        </parameters>
+      </interceptor>
+    </interceptors>
+  </repository>
+</configuration>

--- a/test/DotNetToolkit.Repository.Test/Data/TestConfigurationHelper.cs
+++ b/test/DotNetToolkit.Repository.Test/Data/TestConfigurationHelper.cs
@@ -9,7 +9,7 @@
         {
             return new ConfigurationBuilder()
                 .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
                 .Build();
         }
     }

--- a/test/DotNetToolkit.Repository.Test/DotNetToolkit.Repository.Test.csproj
+++ b/test/DotNetToolkit.Repository.Test/DotNetToolkit.Repository.Test.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
@@ -30,6 +31,12 @@
 
   <ItemGroup>
     <Reference Include="System.Configuration" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/test/DotNetToolkit.Repository.Test/OptionsBuilderTests.cs
+++ b/test/DotNetToolkit.Repository.Test/OptionsBuilderTests.cs
@@ -3,6 +3,7 @@
     using Configuration.Options;
     using Data;
     using InMemory;
+    using Integration.Test.Data;
     using System.Linq;
     using Xunit;
 
@@ -50,6 +51,46 @@
         {
             var optionsBuilder = new RepositoryOptionsBuilder()
                 .UseInMemoryDatabase();
+
+            Assert.NotNull(optionsBuilder.Options.ContextFactory);
+        }
+
+        [Fact]
+        public void ConfigureInterceptorFromAppConfig()
+        {
+            var optionsBuilder = new RepositoryOptionsBuilder()
+                .UseConfiguration();
+
+            Assert.Equal(1, optionsBuilder.Options.Interceptors.Count());
+
+            Assert.True(optionsBuilder.Options.Interceptors.ContainsKey(typeof(TestRepositoryInterceptor)));
+        }
+
+        [Fact]
+        public void ConfigureDefaultContextFactoryFromAppConfig()
+        {
+            var optionsBuilder = new RepositoryOptionsBuilder()
+                .UseConfiguration();
+
+            Assert.NotNull(optionsBuilder.Options.ContextFactory);
+        }
+
+        [Fact]
+        public void ConfigureInterceptorFromAppSetting()
+        {
+            var optionsBuilder = new RepositoryOptionsBuilder()
+                .UseConfiguration(TestConfigurationHelper.GetConfiguration());
+
+            Assert.Equal(1, optionsBuilder.Options.Interceptors.Count());
+
+            Assert.True(optionsBuilder.Options.Interceptors.ContainsKey(typeof(TestRepositoryInterceptor)));
+        }
+
+        [Fact]
+        public void ConfigureDefaultContextFactoryFromAppSetting()
+        {
+            var optionsBuilder = new RepositoryOptionsBuilder()
+                .UseConfiguration(TestConfigurationHelper.GetConfiguration());
 
             Assert.NotNull(optionsBuilder.Options.ContextFactory);
         }

--- a/test/DotNetToolkit.Repository.Test/appsettings.json
+++ b/test/DotNetToolkit.Repository.Test/appsettings.json
@@ -6,7 +6,7 @@
     "interceptors": [
       {
         "interceptor": {
-          "type": "DotNetToolkit.Repository.Integration.Test.Data.TestRepositoryInterceptor, DotNetToolkit.Repository.Integration.Test",
+          "type": "DotNetToolkit.Repository.Test.Data.TestRepositoryInterceptor, DotNetToolkit.Repository.Test",
           "parameters": [
             {
               "parameter": {
@@ -18,19 +18,6 @@
               "parameter": {
                 "type": "System.Boolean",
                 "value": "True"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "interceptor": {
-          "type": "DotNetToolkit.Repository.Integration.Test.Data.TestRepositoryTimeStampInterceptor, DotNetToolkit.Repository.Integration.Test",
-          "parameters": [
-            {
-              "parameter": {
-                "type": "System.String",
-                "value": "random user"
               }
             }
           ]

--- a/test/DotNetToolkit.Repository.Test/appsettings.json
+++ b/test/DotNetToolkit.Repository.Test/appsettings.json
@@ -5,23 +5,17 @@
     },
     "interceptors": [
       {
-        "interceptor": {
-          "type": "DotNetToolkit.Repository.Test.Data.TestRepositoryInterceptor, DotNetToolkit.Repository.Test",
-          "parameters": [
-            {
-              "parameter": {
-                "type": "System.String",
-                "value": "random param"
-              }
-            },
-            {
-              "parameter": {
-                "type": "System.Boolean",
-                "value": "True"
-              }
-            }
-          ]
-        }
+        "type": "DotNetToolkit.Repository.Test.Data.TestRepositoryInterceptor, DotNetToolkit.Repository.Test",
+        "parameters": [
+          {
+            "type": "System.String",
+            "value": "random param"
+          },
+          {
+            "type": "System.Boolean",
+            "value": "True"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Closes #399 

Additionally, the configuration section will no longer need to include a section for a single 'interceptor' or 'parameter' key.