### PR TITLE
Made the type parameter in the config handler optional with a default value of "System.String"

### DIFF
--- a/src/DotNetToolkit.Repository/Internal/ConfigFile/ConfigurationHandler.cs
+++ b/src/DotNetToolkit.Repository/Internal/ConfigFile/ConfigurationHandler.cs
@@ -158,7 +158,12 @@
 
         private static Type ExtractType(IConfigurationSection section)
         {
-            return Type.GetType(Extract(section, TypeKey), throwOnError: true);
+            var value = Extract(section, TypeKey, isRequired: false);
+
+            if (string.IsNullOrEmpty(value))
+                value = "System.String";
+
+            return Type.GetType(value, throwOnError: true);
         }
 
         private static object ExtractParameter(IConfigurationSection section)


### PR DESCRIPTION
#371 