### PR TITLE
Added a new variant to the execute sql function which passes in a repository conventions object

### DIFF
--- a/src/DotNetToolkit.Repository.AdoNet/Internal/DbHelper.cs
+++ b/src/DotNetToolkit.Repository.AdoNet/Internal/DbHelper.cs
@@ -384,7 +384,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         /// <param name="parameters">The command parameters.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>An entity which has been projected into a new form.</returns>
-        public T ExecuteObject<T>(string cmdText, CommandType cmdType, Dictionary<string, object> parameters, Func<DbDataReader, T> projector)
+        public T ExecuteObject<T>(string cmdText, CommandType cmdType, Dictionary<string, object> parameters, Func<DbDataReader, IRepositoryConventions, T> projector)
         {
             using (var reader = ExecuteReader(cmdText, cmdType, parameters))
             {
@@ -392,7 +392,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
 
                 while (reader.Read())
                 {
-                    list.Add(projector(reader));
+                    list.Add(projector(reader, _conventions));
                 }
 
                 var result = list.FirstOrDefault();
@@ -409,7 +409,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         /// <param name="parameters">The command parameters.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>An entity which has been projected into a new form.</returns>
-        public T ExecuteObject<T>(string cmdText, Dictionary<string, object> parameters, Func<DbDataReader, T> projector)
+        public T ExecuteObject<T>(string cmdText, Dictionary<string, object> parameters, Func<DbDataReader, IRepositoryConventions, T> projector)
         {
             return ExecuteObject<T>(cmdText, CommandType.Text, parameters, projector);
         }
@@ -423,7 +423,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         /// <param name="parameters">The command parameters.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
-        public PagedQueryResult<IEnumerable<T>> ExecuteList<T>(string cmdText, CommandType cmdType, Dictionary<string, object> parameters, Func<DbDataReader, T> projector)
+        public PagedQueryResult<IEnumerable<T>> ExecuteList<T>(string cmdText, CommandType cmdType, Dictionary<string, object> parameters, Func<DbDataReader, IRepositoryConventions, T> projector)
         {
             using (var reader = ExecuteReader(cmdText, cmdType, parameters))
             {
@@ -447,7 +447,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
                         }
                     }
 
-                    list.Add(projector(reader));
+                    list.Add(projector(reader, _conventions));
                 }
 
                 if (!foundCrossJoinCountColumn)
@@ -465,7 +465,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         /// <param name="parameters">The command parameters.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
-        public PagedQueryResult<IEnumerable<T>> ExecuteList<T>(string cmdText, Dictionary<string, object> parameters, Func<DbDataReader, T> projector)
+        public PagedQueryResult<IEnumerable<T>> ExecuteList<T>(string cmdText, Dictionary<string, object> parameters, Func<DbDataReader, IRepositoryConventions, T> projector)
         {
             return ExecuteList<T>(cmdText, CommandType.Text, parameters, projector);
         }
@@ -481,7 +481,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         {
             var mapper = new Mapper<T>(_conventions);
 
-            return ExecuteList<T>(cmdText, parameters, mapper.Map);
+            return ExecuteList<T>(cmdText, parameters, (r, c) => mapper.Map(r));
         }
 
         /// <summary>
@@ -492,7 +492,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         /// <param name="cmdType">The command type.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
-        public PagedQueryResult<IEnumerable<T>> ExecuteList<T>(string cmdText, CommandType cmdType, Func<DbDataReader, T> projector)
+        public PagedQueryResult<IEnumerable<T>> ExecuteList<T>(string cmdText, CommandType cmdType, Func<DbDataReader, IRepositoryConventions, T> projector)
         {
             return ExecuteList<T>(cmdText, cmdType, null, projector);
         }
@@ -731,7 +731,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing an entity which has been projected into a new form.</returns>
-        public async Task<T> ExecuteObjectAsync<T>(string cmdText, CommandType cmdType, Dictionary<string, object> parameters, Func<DbDataReader, T> projector, CancellationToken cancellationToken = new CancellationToken())
+        public async Task<T> ExecuteObjectAsync<T>(string cmdText, CommandType cmdType, Dictionary<string, object> parameters, Func<DbDataReader, IRepositoryConventions, T> projector, CancellationToken cancellationToken = new CancellationToken())
         {
             using (var reader = await ExecuteReaderAsync(cmdText, cmdType, parameters, cancellationToken))
             {
@@ -739,7 +739,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
 
                 while (reader.Read())
                 {
-                    list.Add(projector(reader));
+                    list.Add(projector(reader, _conventions));
                 }
 
                 var result = list.FirstOrDefault();
@@ -757,7 +757,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing an entity which has been projected into a new form.</returns>
-        public Task<T> ExecuteObjectAsync<T>(string cmdText, Dictionary<string, object> parameters, Func<DbDataReader, T> projector, CancellationToken cancellationToken = new CancellationToken())
+        public Task<T> ExecuteObjectAsync<T>(string cmdText, Dictionary<string, object> parameters, Func<DbDataReader, IRepositoryConventions, T> projector, CancellationToken cancellationToken = new CancellationToken())
         {
             return ExecuteObjectAsync<T>(cmdText, CommandType.Text, parameters, projector, cancellationToken);
         }
@@ -772,7 +772,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns>
-        public async Task<PagedQueryResult<IEnumerable<T>>> ExecuteListAsync<T>(string cmdText, CommandType cmdType, Dictionary<string, object> parameters, Func<DbDataReader, T> projector, CancellationToken cancellationToken = new CancellationToken())
+        public async Task<PagedQueryResult<IEnumerable<T>>> ExecuteListAsync<T>(string cmdText, CommandType cmdType, Dictionary<string, object> parameters, Func<DbDataReader, IRepositoryConventions, T> projector, CancellationToken cancellationToken = new CancellationToken())
         {
             using (var reader = await ExecuteReaderAsync(cmdText, cmdType, parameters, cancellationToken))
             {
@@ -796,7 +796,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
                         }
                     }
 
-                    list.Add(projector(reader));
+                    list.Add(projector(reader, _conventions));
                 }
 
                 if (!foundCrossJoinCountColumn)
@@ -815,7 +815,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns>
-        public Task<PagedQueryResult<IEnumerable<T>>> ExecuteListAsync<T>(string cmdText, Dictionary<string, object> parameters, Func<DbDataReader, T> projector, CancellationToken cancellationToken = new CancellationToken())
+        public Task<PagedQueryResult<IEnumerable<T>>> ExecuteListAsync<T>(string cmdText, Dictionary<string, object> parameters, Func<DbDataReader, IRepositoryConventions, T> projector, CancellationToken cancellationToken = new CancellationToken())
         {
             return ExecuteListAsync<T>(cmdText, CommandType.Text, parameters, projector, cancellationToken);
         }
@@ -832,7 +832,7 @@ namespace DotNetToolkit.Repository.AdoNet.Internal
         {
             var mapper = new Mapper<T>(_conventions);
 
-            return ExecuteListAsync<T>(cmdText, parameters, mapper.Map, cancellationToken);
+            return ExecuteListAsync<T>(cmdText, parameters, (r, c) => mapper.Map(r), cancellationToken);
         }
 
         /// <summary>

--- a/src/DotNetToolkit.Repository.EntityFramework/Internal/EfRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.EntityFramework/Internal/EfRepositoryContext.cs
@@ -73,6 +73,44 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            Guard.NotEmpty(sql, nameof(sql));
+            Guard.NotNull(projector, nameof(projector));
+
+            var connection = _context.Database.Connection;
+            var command = connection.CreateCommand();
+            var shouldOpenConnection = connection.State != ConnectionState.Open;
+
+            if (shouldOpenConnection)
+                connection.Open();
+
+            command.CommandText = sql;
+            command.CommandType = cmdType;
+            command.Parameters.Clear();
+            command.AddParameters(parameters);
+
+            using (var reader = command.ExecuteReader(shouldOpenConnection ? CommandBehavior.CloseConnection : CommandBehavior.Default))
+            {
+                var list = new List<TEntity>();
+
+                while (reader.Read())
+                {
+                    list.Add(projector(reader, Conventions));
+                }
+
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector)
         {
             Guard.NotEmpty(sql, nameof(sql));
@@ -289,6 +327,45 @@
         protected override Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(IQueryable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, CancellationToken cancellationToken)
         {
             return source.ToDictionaryAsync(keySelector, elementSelector, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        public override async Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            Guard.NotEmpty(sql, nameof(sql));
+            Guard.NotNull(projector, nameof(projector));
+
+            var connection = _context.Database.Connection;
+            var command = connection.CreateCommand();
+            var shouldOpenConnection = connection.State != ConnectionState.Open;
+
+            if (shouldOpenConnection)
+                await connection.OpenAsync(cancellationToken);
+
+            command.CommandText = sql;
+            command.CommandType = cmdType;
+            command.Parameters.Clear();
+            command.AddParameters(parameters);
+
+            using (var reader = await command.ExecuteReaderAsync(shouldOpenConnection ? CommandBehavior.CloseConnection : CommandBehavior.Default, cancellationToken))
+            {
+                var list = new List<TEntity>();
+
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    list.Add(projector(reader, Conventions));
+                }
+
+                return list;
+            }
         }
 
         /// <summary>

--- a/src/DotNetToolkit.Repository.EntityFrameworkCore/Internal/EfCoreRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.EntityFrameworkCore/Internal/EfCoreRepositoryContext.cs
@@ -73,6 +73,44 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            Guard.NotEmpty(sql, nameof(sql));
+            Guard.NotNull(projector, nameof(projector));
+
+            var connection = _context.Database.GetDbConnection();
+            var command = connection.CreateCommand();
+            var shouldOpenConnection = connection.State != ConnectionState.Open;
+
+            if (shouldOpenConnection)
+                connection.Open();
+
+            command.CommandText = sql;
+            command.CommandType = cmdType;
+            command.Parameters.Clear();
+            command.AddParameters(parameters);
+
+            using (var reader = command.ExecuteReader(shouldOpenConnection ? CommandBehavior.CloseConnection : CommandBehavior.Default))
+            {
+                var list = new List<TEntity>();
+
+                while (reader.Read())
+                {
+                    list.Add(projector(reader, Conventions));
+                }
+
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector)
         {
             Guard.NotEmpty(sql, nameof(sql));
@@ -292,6 +330,45 @@
         protected override Task<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(IQueryable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, CancellationToken cancellationToken)
         {
             return source.ToDictionaryAsync(keySelector, elementSelector, cancellationToken);
+        }
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        public override async Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            Guard.NotEmpty(sql, nameof(sql));
+            Guard.NotNull(projector, nameof(projector));
+
+            var connection = _context.Database.GetDbConnection();
+            var command = connection.CreateCommand();
+            var shouldOpenConnection = connection.State != ConnectionState.Open;
+
+            if (shouldOpenConnection)
+                await connection.OpenAsync(cancellationToken);
+
+            command.CommandText = sql;
+            command.CommandType = cmdType;
+            command.Parameters.Clear();
+            command.AddParameters(parameters);
+
+            using (var reader = await command.ExecuteReaderAsync(shouldOpenConnection ? CommandBehavior.CloseConnection : CommandBehavior.Default, cancellationToken))
+            {
+                var list = new List<TEntity>();
+
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    list.Add(projector(reader, Conventions));
+                }
+
+                return list;
+            }
         }
 
         /// <summary>

--- a/src/DotNetToolkit.Repository.InMemory/Internal/InMemoryRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository.InMemory/Internal/InMemoryRepositoryContext.cs
@@ -268,6 +268,25 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            if (!_ignoreSqlQueryWarning)
+                throw new NotSupportedException(Repository.Properties.Resources.QueryExecutionNotSupported);
+
+            Guard.NotEmpty(sql, nameof(sql));
+            Guard.NotNull(projector, nameof(projector));
+
+            return Enumerable.Empty<TEntity>();
+        }
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector)
         {
             if (!_ignoreSqlQueryWarning)

--- a/src/DotNetToolkit.Repository.Json/Internal/FileStreamRepositoryContextBase.cs
+++ b/src/DotNetToolkit.Repository.Json/Internal/FileStreamRepositoryContextBase.cs
@@ -314,6 +314,25 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            if (!_ignoreSqlQueryWarning)
+                throw new NotSupportedException(Repository.Properties.Resources.QueryExecutionNotSupported);
+
+            Guard.NotEmpty(sql, nameof(sql));
+            Guard.NotNull(projector, nameof(projector));
+
+            return Enumerable.Empty<TEntity>();
+        }
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector)
         {
             if (!_ignoreSqlQueryWarning)

--- a/src/DotNetToolkit.Repository.Xml/Internal/FileStreamRepositoryContextBase.cs
+++ b/src/DotNetToolkit.Repository.Xml/Internal/FileStreamRepositoryContextBase.cs
@@ -314,6 +314,25 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            if (!_ignoreSqlQueryWarning)
+                throw new NotSupportedException(Repository.Properties.Resources.QueryExecutionNotSupported);
+
+            Guard.NotEmpty(sql, nameof(sql));
+            Guard.NotNull(projector, nameof(projector));
+
+            return Enumerable.Empty<TEntity>();
+        }
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         public override IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector)
         {
             if (!_ignoreSqlQueryWarning)

--- a/src/DotNetToolkit.Repository/Configuration/IRepositoryContext.cs
+++ b/src/DotNetToolkit.Repository/Configuration/IRepositoryContext.cs
@@ -24,6 +24,16 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector) where TEntity : class;
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector) where TEntity : class;
 
         /// <summary>

--- a/src/DotNetToolkit.Repository/Configuration/IRepositoryContextAsync.cs
+++ b/src/DotNetToolkit.Repository/Configuration/IRepositoryContextAsync.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNetToolkit.Repository.Configuration
 {
+    using Conventions;
     using Queries;
     using Queries.Strategies;
     using System;
@@ -16,6 +17,17 @@
     /// <seealso cref="System.IDisposable" />
     public interface IRepositoryContextAsync : IRepositoryContext, IDisposable
     {
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken()) where TEntity : class;
+
         /// <summary>
         /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
         /// </summary>

--- a/src/DotNetToolkit.Repository/Configuration/LinqRepositoryContextBase.cs
+++ b/src/DotNetToolkit.Repository/Configuration/LinqRepositoryContextBase.cs
@@ -95,7 +95,20 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
-        public virtual IEnumerable<TEntity> ExecuteSqlQuery<TEntity>([NotNull] string sql, CommandType cmdType, [CanBeNull] Dictionary<string, object> parameters, [NotNull] Func<IDataReader, TEntity> projector) where TEntity : class
+        public virtual IEnumerable<TEntity> ExecuteSqlQuery<TEntity>([NotNull] string sql, CommandType cmdType, [CanBeNull] Dictionary<string, object> parameters, [NotNull] Func<IDataReader, IRepositoryConventions, TEntity> projector) where TEntity : class
+        {
+            throw new NotSupportedException(Resources.QueryExecutionNotSupported);
+        }
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
+        public virtual IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector) where TEntity : class
         {
             throw new NotSupportedException(Resources.QueryExecutionNotSupported);
         }

--- a/src/DotNetToolkit.Repository/Configuration/LinqRepositoryContextBaseAsync.cs
+++ b/src/DotNetToolkit.Repository/Configuration/LinqRepositoryContextBaseAsync.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNetToolkit.Repository.Configuration
 {
+    using Conventions;
     using Extensions;
     using JetBrains.Annotations;
     using Properties;
@@ -60,7 +61,21 @@
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
-        public virtual Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync<TEntity>([NotNull] string sql, CommandType cmdType, [CanBeNull] Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector, CancellationToken cancellationToken = new CancellationToken()) where TEntity : class
+        public virtual Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync<TEntity>([NotNull] string sql, CommandType cmdType, [CanBeNull] Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken()) where TEntity : class
+        {
+            throw new NotSupportedException(Resources.QueryExecutionNotSupported);
+        }
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        public virtual Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector, CancellationToken cancellationToken = new CancellationToken()) where TEntity : class
         {
             throw new NotSupportedException(Resources.QueryExecutionNotSupported);
         }

--- a/src/DotNetToolkit.Repository/Extensions/CachingProviderExtensions.cs
+++ b/src/DotNetToolkit.Repository/Extensions/CachingProviderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace DotNetToolkit.Repository.Extensions
 {
     using Configuration.Caching;
+    using Configuration.Conventions;
     using Configuration.Logging;
     using JetBrains.Annotations;
     using Queries;
@@ -287,6 +288,19 @@
             [NotNull] this ICacheProvider cacheProvider,
             [NotNull] string sql, CommandType cmdType,
             [CanBeNull] Dictionary<string, object> parameters,
+            [NotNull] Func<IDataReader, IRepositoryConventions, T> projector,
+            [NotNull] Func<IEnumerable<T>> getter,
+            [NotNull] ILogger logger)
+            => GetOrSet<T, IEnumerable<T>>(
+                cacheProvider,
+                FormatGetOrSetExecuteSqlQueryKey<T>(sql, cmdType, parameters),
+                getter,
+                logger);
+
+        internal static ICacheQueryResult<IEnumerable<T>> GetOrSetExecuteSqlQuery<T>(
+            [NotNull] this ICacheProvider cacheProvider,
+            [NotNull] string sql, CommandType cmdType,
+            [CanBeNull] Dictionary<string, object> parameters,
             [NotNull] Func<IDataReader, T> projector,
             [NotNull] Func<IEnumerable<T>> getter,
             [NotNull] ILogger logger)
@@ -378,6 +392,20 @@
             => GetOrSet<T, IEnumerable<TResult>>(
                 cacheProvider,
                 FormatGetOrSetGroupKey<T, TGroupKey, TResult>(options, keySelector, resultSelector),
+                getter,
+                logger);
+
+        internal static Task<ICacheQueryResult<IEnumerable<T>>> GetOrSetExecuteSqlQueryAsync<T>(
+            [NotNull] this ICacheProvider cacheProvider,
+            [NotNull] string sql,
+            CommandType cmdType,
+            [CanBeNull] Dictionary<string, object> parameters,
+            [NotNull] Func<IDataReader, IRepositoryConventions, T> projector,
+            [NotNull] Func<Task<IEnumerable<T>>> getter,
+            [NotNull] ILogger logger)
+            => GetOrSetAsync<T, IEnumerable<T>>(
+                cacheProvider,
+                FormatGetOrSetExecuteSqlQueryKey<T>(sql, cmdType, parameters),
                 getter,
                 logger);
 

--- a/src/DotNetToolkit.Repository/IReadOnlyRepository.cs
+++ b/src/DotNetToolkit.Repository/IReadOnlyRepository.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNetToolkit.Repository
 {
+    using Configuration.Conventions;
     using Queries;
     using Queries.Strategies;
     using System;
@@ -60,6 +61,33 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector);
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector);
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector);
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, TEntity> projector);
 
         /// <summary>
@@ -105,6 +133,36 @@
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing A list which each entity has been projected into a new form using a default mapping provider.</returns> 
         Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CancellationToken cancellationToken = new CancellationToken());
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken());
+
+        /// <summary>
+        /// Asynchronously creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken());
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken());
 
         /// <summary>
         /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
@@ -599,6 +657,33 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector);
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector);
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector);
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, TEntity> projector);
 
         /// <summary>
@@ -644,6 +729,36 @@
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing A list which each entity has been projected into a new form using a default mapping provider.</returns> 
         Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CancellationToken cancellationToken = new CancellationToken());
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken());
+
+        /// <summary>
+        /// Asynchronously creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken());
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken());
 
         /// <summary>
         /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
@@ -1131,6 +1246,33 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector);
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector);
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
+        IEnumerable<TEntity> ExecuteSqlQuery(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector);
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, TEntity> projector);
 
         /// <summary>
@@ -1176,6 +1318,36 @@
         /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing A list which each entity has been projected into a new form using a default mapping provider.</returns> 
         Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CancellationToken cancellationToken = new CancellationToken());
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken());
+
+        /// <summary>
+        /// Asynchronously creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken());
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken());
 
         /// <summary>
         /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.

--- a/src/DotNetToolkit.Repository/Internal/ReadOnlyRepositoryWrapper.cs
+++ b/src/DotNetToolkit.Repository/Internal/ReadOnlyRepositoryWrapper.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNetToolkit.Repository.Internal
 {
+    using Configuration.Conventions;
     using Queries;
     using Queries.Strategies;
     using System;
@@ -62,6 +63,21 @@
             return _underlyingRepo.ExecuteSqlQuery(sql);
         }
 
+        public IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            return _underlyingRepo.ExecuteSqlQuery(sql, cmdType, parameters, projector);
+        }
+
+        public IEnumerable<TEntity> ExecuteSqlQuery(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            return _underlyingRepo.ExecuteSqlQuery(sql, parameters, projector);
+        }
+
+        public IEnumerable<TEntity> ExecuteSqlQuery(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            return _underlyingRepo.ExecuteSqlQuery(sql, projector);
+        }
+
         public IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, TEntity> projector)
         {
             return _underlyingRepo.ExecuteSqlQuery(sql, cmdType, parameters, projector);
@@ -90,6 +106,21 @@
         public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CancellationToken cancellationToken = new CancellationToken())
         {
             return _underlyingRepo.ExecuteSqlQueryAsync(sql, cancellationToken);
+        }
+
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _underlyingRepo.ExecuteSqlQueryAsync(sql, cmdType, parameters, projector, cancellationToken);
+        }
+
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _underlyingRepo.ExecuteSqlQueryAsync(sql, parameters, projector, cancellationToken);
+        }
+
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _underlyingRepo.ExecuteSqlQueryAsync(sql, projector, cancellationToken);
         }
 
         public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
@@ -402,6 +433,21 @@
             return _underlyingRepo.ExecuteSqlQuery(sql);
         }
 
+        public IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            return _underlyingRepo.ExecuteSqlQuery(sql, cmdType, parameters, projector);
+        }
+
+        public IEnumerable<TEntity> ExecuteSqlQuery(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            return _underlyingRepo.ExecuteSqlQuery(sql, parameters, projector);
+        }
+
+        public IEnumerable<TEntity> ExecuteSqlQuery(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            return _underlyingRepo.ExecuteSqlQuery(sql, projector);
+        }
+
         public IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, TEntity> projector)
         {
             return _underlyingRepo.ExecuteSqlQuery(sql, cmdType, parameters, projector);
@@ -430,6 +476,21 @@
         public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CancellationToken cancellationToken = new CancellationToken())
         {
             return _underlyingRepo.ExecuteSqlQueryAsync(sql, cancellationToken);
+        }
+
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _underlyingRepo.ExecuteSqlQueryAsync(sql, cmdType, parameters, projector, cancellationToken);
+        }
+
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _underlyingRepo.ExecuteSqlQueryAsync(sql, parameters, projector, cancellationToken);
+        }
+
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _underlyingRepo.ExecuteSqlQueryAsync(sql, projector, cancellationToken);
         }
 
         public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
@@ -742,6 +803,21 @@
             return _underlyingRepo.ExecuteSqlQuery(sql);
         }
 
+        public IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            return _underlyingRepo.ExecuteSqlQuery(sql, cmdType, parameters, projector);
+        }
+
+        public IEnumerable<TEntity> ExecuteSqlQuery(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            return _underlyingRepo.ExecuteSqlQuery(sql, parameters, projector);
+        }
+
+        public IEnumerable<TEntity> ExecuteSqlQuery(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector)
+        {
+            return _underlyingRepo.ExecuteSqlQuery(sql, projector);
+        }
+
         public IEnumerable<TEntity> ExecuteSqlQuery(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, TEntity> projector)
         {
             return _underlyingRepo.ExecuteSqlQuery(sql, cmdType, parameters, projector);
@@ -770,6 +846,21 @@
         public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CancellationToken cancellationToken = new CancellationToken())
         {
             return _underlyingRepo.ExecuteSqlQueryAsync(sql, cancellationToken);
+        }
+
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _underlyingRepo.ExecuteSqlQueryAsync(sql, cmdType, parameters, projector, cancellationToken);
+        }
+
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, object[] parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _underlyingRepo.ExecuteSqlQueryAsync(sql, parameters, projector, cancellationToken);
+        }
+
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return _underlyingRepo.ExecuteSqlQueryAsync(sql, projector, cancellationToken);
         }
 
         public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync(string sql, CommandType cmdType, object[] parameters, Func<IDataReader, TEntity> projector, CancellationToken cancellationToken = new CancellationToken())

--- a/src/DotNetToolkit.Repository/Internal/RepositoryContextAsyncWrapper.cs
+++ b/src/DotNetToolkit.Repository/Internal/RepositoryContextAsyncWrapper.cs
@@ -65,6 +65,19 @@
         /// <param name="parameters">The parameters to apply to the SQL query string.</param>
         /// <param name="projector">A function to project each entity into a new form.</param>
         /// <returns>A list which each entity has been projected into a new form.</returns>
+        public IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector) where TEntity : class
+        {
+            return _context.ExecuteSqlQuery(sql, cmdType, parameters, projector);
+        }
+
+        /// <summary>
+        /// Creates a raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <returns>A list which each entity has been projected into a new form.</returns>
         public IEnumerable<TEntity> ExecuteSqlQuery<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, TEntity> projector) where TEntity : class
         {
             return _context.ExecuteSqlQuery(sql, cmdType, parameters, projector);
@@ -246,6 +259,25 @@
         #endregion
 
         #region Implementation of IRepositoryContextAsync
+
+        /// <summary>
+        /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.
+        /// </summary>
+        /// <param name="sql">The SQL query string.</param>
+        /// <param name="cmdType">The command type.</param>
+        /// <param name="parameters">The parameters to apply to the SQL query string.</param>
+        /// <param name="projector">A function to project each entity into a new form.</param>
+        /// <param name="cancellationToken">A <see cref="System.Threading.CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>The <see cref="System.Threading.Tasks.Task" /> that represents the asynchronous operation, containing a list which each entity has been projected into a new form.</returns> 
+        public Task<IEnumerable<TEntity>> ExecuteSqlQueryAsync<TEntity>(string sql, CommandType cmdType, Dictionary<string, object> parameters, Func<IDataReader, IRepositoryConventions, TEntity> projector, CancellationToken cancellationToken = new CancellationToken()) where TEntity : class
+        {
+            if (_context is IRepositoryContextAsync contextAsync)
+            {
+                return contextAsync.ExecuteSqlQueryAsync(sql, cmdType, parameters, projector, cancellationToken);
+            }
+
+            return RunAsync<IEnumerable<TEntity>>(() => ExecuteSqlQuery(sql, cmdType, parameters, projector), cancellationToken);
+        }
 
         /// <summary>
         /// Asynchronously creates raw SQL query that is executed directly in the database and returns a collection of entities.

--- a/test/DotNetToolkit.Repository.Integration.Test/RepositoryTests.cs
+++ b/test/DotNetToolkit.Repository.Integration.Test/RepositoryTests.cs
@@ -25,18 +25,6 @@
         }
 
         [Fact]
-        public void ThrowsIfModelHasNoId()
-        {
-            ForAllRepositoryFactories(TestThrowsIfModelHasNoId);
-        }
-
-        [Fact]
-        public void ThrowsIfEntityPrimaryKeyTypesMismatch()
-        {
-            ForAllRepositoryFactories(TestThrowsIfEntityPrimaryKeyTypesMismatch);
-        }
-
-        [Fact]
         public void ThrowsIfSpecificationMissingFromQueryOptions()
         {
             ForAllRepositoryFactories(TestThrowsIfSpecificationMissingFromQueryOptions);
@@ -46,13 +34,6 @@
         public void ThrowsIfSpecificationMissingFromQueryOptionsAsync()
         {
             ForAllRepositoryFactoriesAsync(TestThrowsIfSpecificationMissingFromQueryOptionsAsync);
-        }
-
-        [Fact]
-        public void ThrowsIfEntityCompositePrimaryKeyMissingOrdering()
-        {
-            // not needed for hibernate
-            ForAllRepositoryFactories(TestThrowsIfEntityCompositePrimaryKeyMissingOrdering, ContextProviderType.NHibernate);
         }
 
         private static void TestFactoryCreate(IRepositoryFactory repoFactory)
@@ -87,13 +68,6 @@
             Assert.Equal(readOnlyRepo4, repo4.AsReadOnly());
         }
 
-        private static void TestThrowsIfModelHasNoId(IRepositoryFactory repoFactory)
-        {
-            var ex = Assert.Throws<InvalidOperationException>(() => repoFactory.Create<CustomerWithNoId>());
-
-            Assert.Equal($"The instance of entity type '{typeof(CustomerWithNoId).FullName}' requires a primary key to be defined.", ex.Message);
-        }
-
         private static void TestThrowsIfSpecificationMissingFromQueryOptions(IRepositoryFactory repoFactory)
         {
             var repo = repoFactory.Create<Customer>();
@@ -116,30 +90,6 @@
 
             ex = await Assert.ThrowsAsync<InvalidOperationException>(() => repo.DeleteAsync(emptyQueryOptions));
             Assert.Equal("The specified query options is missing a specification predicate.", ex.Message);
-        }
-
-        private static void TestThrowsIfEntityPrimaryKeyTypesMismatch(IRepositoryFactory repoFactory)
-        {
-            var ex = Assert.Throws<InvalidOperationException>(() => repoFactory.Create<Customer, string>());
-            Assert.Equal("The repository primary key type(s) constraint must match the number of primary key type(s) and ordering defined on the entity.", ex.Message);
-
-            ex = Assert.Throws<InvalidOperationException>(() => repoFactory.Create<CustomerWithThreeCompositePrimaryKey, string>());
-            Assert.Equal("The repository primary key type(s) constraint must match the number of primary key type(s) and ordering defined on the entity.", ex.Message);
-
-            ex = Assert.Throws<InvalidOperationException>(() => repoFactory.Create<CustomerWithThreeCompositePrimaryKey, string, string>());
-            Assert.Equal("The repository primary key type(s) constraint must match the number of primary key type(s) and ordering defined on the entity.", ex.Message);
-
-            ex = Assert.Throws<InvalidOperationException>(() => repoFactory.Create<CustomerWithThreeCompositePrimaryKey, int, string>());
-            Assert.Equal("The repository primary key type(s) constraint must match the number of primary key type(s) and ordering defined on the entity.", ex.Message);
-
-            ex = Assert.Throws<InvalidOperationException>(() => repoFactory.Create<CustomerWithThreeCompositePrimaryKey, string, int>());
-            Assert.Equal("The repository primary key type(s) constraint must match the number of primary key type(s) and ordering defined on the entity.", ex.Message);
-        }
-
-        private static void TestThrowsIfEntityCompositePrimaryKeyMissingOrdering(IRepositoryFactory repoFactory)
-        {
-            var ex = Assert.Throws<InvalidOperationException>(() => repoFactory.Create<CustomerWithThreeCompositePrimaryKeyAndNoOrder, int, string, int>());
-            Assert.Equal($"Unable to determine composite primary key ordering for type '{typeof(CustomerWithThreeCompositePrimaryKeyAndNoOrder).FullName}'. Use the ColumnAttribute to specify an order for composite primary keys.", ex.Message);
         }
     }
 }

--- a/test/DotNetToolkit.Repository.Test/OptionsBuilderTests.cs
+++ b/test/DotNetToolkit.Repository.Test/OptionsBuilderTests.cs
@@ -71,11 +71,6 @@
                 .UseConventions(conventions);
 
             Assert.NotNull(optionsBuilder.Options.Conventions);
-
-            // will fail since it cannot find a primary key due to the conventions returning null
-            var ex = Assert.Throws<InvalidOperationException>(() => new Repository<Customer>(optionsBuilder.Options));
-
-            Assert.Equal($"The instance of entity type '{typeof(Customer).FullName}' requires a primary key to be defined.", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Closes #481 

Additionally, this will remove any checks being for an entity not having a valid primary key definition when a repository is initialized. If this is needed in the future, it should probably be done in the context level, not the repository.