### PR TITLE
(GH-597) Allowed the primary key conventions helper to get the key from a base class

### DIFF
--- a/src/DotNetToolkit.Repository/Configuration/Conventions/Internal/PrimaryKeyConventionHelper.cs
+++ b/src/DotNetToolkit.Repository/Configuration/Conventions/Internal/PrimaryKeyConventionHelper.cs
@@ -36,7 +36,7 @@
             {
                 foreach (var propertyName in GetDefaultPrimaryKeyNameChecks(entityType))
                 {
-                    var propertyInfo = entityType.GetTypeInfo().GetDeclaredProperty(propertyName);
+                    var propertyInfo = entityType.GetProperty(propertyName);
 
                     if (propertyInfo != null && conventions.IsColumnMapped(propertyInfo))
                     {


### PR DESCRIPTION
Closes #597 